### PR TITLE
handling CalledProcessError, among other exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
 FROM python:3.6
 
-RUN apt-get update && apt-get install -y \
-  curl \
-  vim
-
-RUN cd /usr/local/bin && \
-  curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.2/bin/linux/amd64/kubectl && \
-  chmod 755 /usr/local/bin/kubectl
-
 WORKDIR /usr/src/app
 
 COPY requirements.txt .

--- a/redis-janitor.py
+++ b/redis-janitor.py
@@ -31,6 +31,7 @@ import os
 import sys
 import time
 import logging
+import traceback
 
 import redis
 
@@ -81,4 +82,5 @@ if __name__ == '__main__':
             time.sleep(INTERVAL)
         except Exception as err:  # pylint: disable=broad-except
             _logger.critical('Fatal Error: %s: %s', type(err).__name__, err)
+            print(traceback.format_exc())
             sys.exit(1)

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -28,69 +28,50 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import re
 import time
 import timeit
 import logging
-import subprocess
 
 import redis
+import kubernetes.client
 
 
 class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
 
-    def __init__(self, redis_client, backoff=3):
+    def __init__(self, redis_client, kube_client, backoff=3):
         self.redis_client = redis_client
+        self.kube_client = kube_client
         self._repairs = 0
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.backoff = backoff
 
-    def _make_kubectl_call(self, args):
-        argstring = ' '.join(args)
-        try:
-            t = timeit.default_timer()
-            subprocess.run(args)
-            self.logger.debug('Executed subprocess: `%s` in %s seconds.',
-                              argstring, timeit.default_timer() - t)
-        except subprocess.CalledProcessError as err:
-            # Who knows what's going on.
-            # Let it go and see if the parent loop brings us back around.
-            self.logger.warning('Encountered %s while executing `%s`. '
-                                'Possibly retrying soon...',
-                                type(err).__name__, err)
-            time.sleep(self.backoff)
-
-    def _get_all_pods(self, args=['kubectl', 'get', 'pods', '-a']):
-        argstring = ' '.join(args)
-        while True:
-            try:
-                t = timeit.default_timer()
-                pods_info = subprocess.check_output(args)
-                pods = pods_info.decode('utf8')
-                self.logger.debug('Executed subprocess: `%s` in %s seconds.',
-                                  argstring, timeit.default_timer() - t)
-                break
-            except subprocess.CalledProcessError as err:
-                # For some reason, we can't execute this command right now.
-                # Keep trying until we can.
-                self.logger.warning('Encountered %s: %s while executing `%s`. '
-                                    'Retrying in %s seconds...', argstring,
-                                    type(err).__name__, err, self.backoff)
-                time.sleep(self.backoff)
-        return '\n'.join(x for x in pods.splitlines() if x)
-
-    def kill_pod(self, host):
+    def kill_pod(self, pod_name, namespace):
         # delete the pod
-        kill_args = ['kubectl', 'delete', 'pods', host]
-        while True:  # repeat until the pod is gone
-            self._make_kubectl_call(kill_args)
-            try:
-                pods_str = self._get_all_pods()
-                _ = re.search(r'%s +\S+ +(\S+)' % host, pods_str).group(1)
-            except AttributeError:
-                self.logger.info('Pod %s successfully deleted', host)
-                break  # pod no longer exists
-            time.sleep(self.backoff)
+        t = timeit.default_timer()
+        try:
+            response = self.kube_client.delete_namespaced_pod(
+                pod_name, namespace, grace_period_seconds=0)
+        except kubernetes.client.rest.ApiException as err:
+            self.logger.warning('Encountered %s: %s when calling '
+                                '`delete_namespaced_pod`. ',
+                                type(err).__name__, err)
+            raise err
+        self.logger.debug('Killed pod `%s` in namespace `%s` in %s seconds.',
+                          pod_name, namespace, timeit.default_timer() - t)
+        return response
+
+    def list_pod_for_all_namespaces(self):
+        t = timeit.default_timer()
+        try:
+            response = self.kube_client.list_pod_for_all_namespaces()
+        except kubernetes.client.rest.ApiException as err:
+            self.logger.error('Encountered %s: %s when calling '
+                              '`list_pod_for_all_namespaces`. ',
+                              type(err).__name__, err)
+            raise err
+        self.logger.debug('Found %s pods in %s seconds.',
+                          len(response.items), timeit.default_timer() - t)
+        return response.items
 
     def hset(self, rhash, key, value):
         while True:
@@ -121,10 +102,6 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             except Exception as err:
                 self.logger.error('Unexpected %s: %s when calling SCAN.',
                                   type(err).__name__, err)
-                raise err
-            except:
-                self.logger.error('Caught uncatchable exception while calling'
-                                  ' `SCAN`.')
                 raise err
         return response
 
@@ -177,7 +154,7 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                 raise err
         return response
 
-    def triage(self, key, pods):
+    def triage(self, key, all_pods):
         key_status = self.hget(key, 'status')
 
         if key_status not in {'new', 'done', 'failed'}:
@@ -185,25 +162,25 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             host = self.hget(key, 'identity_started')
 
             if not host:
-                self.logger.info('Entry `%s` is malformed. %s',
-                                 key, self.hgetall(key))
+                self.logger.warning('Entry `%s` is malformed. %s',
+                                    key, self.hgetall(key))
                 return False
 
             try:
-                pod_status = re.search(r'%s +\S+ +(\S+)' % host, pods).group(1)
-            except AttributeError:  # pod not found, reset the status
+                pod = [p for p in all_pods if p.metadata.name == host][0]
+            except IndexError:
                 self.logger.info('Pod %s is AWOL. Resetting record %s.', host, key)
                 self.hset(key, 'status', 'new')
                 return True
 
             # the pod's still around, but is something wrong with it?
-            if pod_status != 'Running':
+            if pod.status.phase != 'Running':
                 # we need to make sure it gets killed
                 # and then reset the status of the job
                 self.logger.info('Pod %s is in status `%s`.  Killing it '
                                  'and then resetting record %s.',
-                                 host, pod_status, key)
-                self.kill_pod(host)
+                                 host, pod.status.phase, key)
+                self.kill_pod(host, 'deepcell')  # TODO: hardcoded namespace
                 self.hset(key, 'status', 'new')
                 return True
 
@@ -245,8 +222,8 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
         repairs = 0
 
         # get list of all pods
-        pods = self._get_all_pods()
-        self.logger.debug('Found %s pods.', len(pods.splitlines()))
+        pods = self.list_pod_for_all_namespaces()
+        self.logger.info('Found %s pods.', len(pods))
 
         for key in self.scan_iter():
             if self._redis_type(key) == 'hash':

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -104,7 +104,7 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             try:
                 response = self.redis_client.hset(rhash, key, value)
                 break
-            except redis.exceptions.ConnectionError as err:
+            except (ConnectionError, redis.exceptions.ConnectionError) as err:
                 self.logger.warning('Encountered %s: %s when calling HSET. '
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
@@ -120,7 +120,7 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             try:
                 response = self.redis_client.scan_iter(match=match)
                 break
-            except redis.exceptions.ConnectionError as err:
+            except (ConnectionError, redis.exceptions.ConnectionError) as err:
                 self.logger.warning('Encountered %s: %s when calling SCAN. '
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
@@ -136,7 +136,7 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             try:
                 response = self.redis_client.type(redis_key)
                 break
-            except redis.exceptions.ConnectionError as err:
+            except (ConnectionError, redis.exceptions.ConnectionError) as err:
                 self.logger.warning('Encountered %s: %s when calling TYPE. '
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
@@ -152,7 +152,7 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             try:
                 response = self.redis_client.hget(rhash, key)
                 break
-            except redis.exceptions.ConnectionError as err:
+            except (ConnectionError, redis.exceptions.ConnectionError) as err:
                 self.logger.warning('Encountered %s: %s when calling HGET. '
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
@@ -168,7 +168,7 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             try:
                 response = self.redis_client.hgetall(rhash)
                 break
-            except redis.exceptions.ConnectionError as err:
+            except (ConnectionError, redis.exceptions.ConnectionError) as err:
                 self.logger.warning('Encountered %s: %s when calling HGETALL. '
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -109,12 +109,10 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
-            except:
-                # Why didn't we catch this?
-                self.logger.error('Encountered %s: %s when calling HSET. '
-                                  'Retrying in %s seconds.',
-                                  type(err).__name__, err, self.backoff)
-                time.sleep(self.backoff)
+            except Exception as err:
+                self.logger.error('Unexpected %s: %s when calling HSET.',
+                                  type(err).__name__, err)
+                raise err
         return response
 
     def scan_iter(self, match=None):
@@ -127,12 +125,10 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
-            except:
-                # Why didn't we catch this?
-                self.logger.error('Encountered %s: %s when calling SCAN. '
-                                  'Retrying in %s seconds.',
-                                  type(err).__name__, err, self.backoff)
-                time.sleep(self.backoff)
+            except Exception as err:
+                self.logger.error('Unexpected %s: %s when calling SCAN.',
+                                  type(err).__name__, err)
+                raise err
         return response
 
     def _redis_type(self, redis_key):
@@ -145,12 +141,10 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
-            except:
-                # Why didn't we catch this?
-                self.logger.error('Encountered %s: %s when calling TYPE. '
-                                  'Retrying in %s seconds.',
-                                  type(err).__name__, err, self.backoff)
-                time.sleep(self.backoff)
+            except Exception as err:
+                self.logger.error('Unexpected %s: %s when calling TYPE.',
+                                  type(err).__name__, err)
+                raise err
         return response
 
     def hget(self, rhash, key):
@@ -163,12 +157,10 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
-            except:
-                # Why didn't we catch this?
-                self.logger.error('Encountered %s: %s when calling HGET. '
-                                  'Retrying in %s seconds.',
-                                  type(err).__name__, err, self.backoff)
-                time.sleep(self.backoff)
+            except Exception as err:
+                self.logger.error('Unexpected %s: %s when calling HGET.',
+                                  type(err).__name__, err)
+                raise err
         return response
 
     def hgetall(self, rhash):
@@ -181,12 +173,11 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
-            except:
+            except Exception as err:
                 # Why didn't we catch this?
-                self.logger.error('Encountered %s: %s when calling HGETALL. '
-                                  'Retrying in %s seconds.',
-                                  type(err).__name__, err, self.backoff)
-                time.sleep(self.backoff)
+                self.logger.error('Unexpected %s: %s when calling HGETALL. ',
+                                  type(err).__name__, err)
+                raise err
         return response
 
     def triage(self, key, pods):

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -122,6 +122,10 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                 self.logger.error('Unexpected %s: %s when calling SCAN.',
                                   type(err).__name__, err)
                 raise err
+            except:
+                self.logger.error('Caught uncatchable exception while calling'
+                                  ' `SCAN`.')
+                raise err
         return response
 
     def _redis_type(self, redis_key):

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -125,6 +125,12 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
+            except:
+                # Why didn't we catch this?
+                self.logger.error('Encountered %s: %s when calling HSET. '
+                                    'Retrying in %s seconds.',
+                                    type(err).__name__, err, self.backoff)
+                time.sleep(self.backoff)
         return response
 
     def scan_iter(self, match=None):
@@ -134,6 +140,12 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                 break
             except redis.exceptions.ConnectionError as err:
                 self.logger.warning('Encountered %s: %s when calling SCAN. '
+                                    'Retrying in %s seconds.',
+                                    type(err).__name__, err, self.backoff)
+                time.sleep(self.backoff)
+            except:
+                # Why didn't we catch this?
+                self.logger.error('Encountered %s: %s when calling SCAN. '
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
@@ -149,6 +161,12 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
+            except:
+                # Why didn't we catch this?
+                self.logger.error('Encountered %s: %s when calling TYPE. '
+                                    'Retrying in %s seconds.',
+                                    type(err).__name__, err, self.backoff)
+                time.sleep(self.backoff)
         return response
 
     def hget(self, rhash, key):
@@ -161,6 +179,12 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
+            except:
+                # Why didn't we catch this?
+                self.logger.error('Encountered %s: %s when calling HGET. '
+                                    'Retrying in %s seconds.',
+                                    type(err).__name__, err, self.backoff)
+                time.sleep(self.backoff)
         return response
 
     def hgetall(self, rhash):
@@ -170,6 +194,12 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                 break
             except redis.exceptions.ConnectionError as err:
                 self.logger.warning('Encountered %s: %s when calling HGETALL. '
+                                    'Retrying in %s seconds.',
+                                    type(err).__name__, err, self.backoff)
+                time.sleep(self.backoff)
+            except:
+                # Why didn't we catch this?
+                self.logger.error('Encountered %s: %s when calling HGETALL. '
                                     'Retrying in %s seconds.',
                                     type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -95,7 +95,7 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                 # Keep trying until we can.
                 self.logger.warning('Encountered %s: %s while executing with '
                                     'parameters: %s.  etrying in %s seconds...',
-                                    parameter_list, type(err).__name__, err,
+                                    kill_args, type(err).__name__, err,
                                     self.backoff)
                 time.sleep(self.backoff)
 

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -92,9 +92,14 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             except AttributeError:
                 self.logger.info('Pod %s successfully deleted', host)
                 break  # pod no longer exists
-            self.logger.debug('Waiting for pod `%s` to be deleted. '
-                              'Sleeping for %s seconds.', host, self.backoff)
-            time.sleep(self.backoff)
+            except subprocess.CalledProcessError as err:
+                # For some reason, we can't execute this command right now.
+                # Keep trying until we can.
+                self.logger.warning('Encountered %s: %s while executing with '
+                                    'parameters: %s.  etrying in %s seconds...',
+                                    parameter_list, type(err).__name__, err,
+                                    self.backoff)
+                time.sleep(self.backoff)
 
     def hset(self, rhash, key, value):
         while True:

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -58,9 +58,12 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                 # For some reason, we can't execute this command right now.
                 # Let's see if we can find out why.
                 error_info = subprocess.check_output(args)
+                self.logger.warning("Error info: %s", error_info)
                 potential_error_string = \
                     "Error from server (NotFound): pods" + \
                     " \"{}\" not found".format(args[-1])
+                self.logger.warning("Potential error string: %s",
+                                    potential_error_string)
                 if error_info == potential_error_string:
                     # We are trying to delete a pod which no longer exists.
                     # Relax, it's ok to exit on an error here.
@@ -68,8 +71,8 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                 else:
                     # Who knows what's going on.
                     # Keep trying until we succeed.
-                    self.logger.warning('Encountered %s: %s while executing `%s`. '
-                                        'Retrying in %s seconds...', argstring,
+                    self.logger.warning('Encountered %s while executing `%s`. '
+                                        'Retrying in %s seconds...',
                                         type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
 
@@ -208,7 +211,7 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
 
             try:
                 last_update = float(self.hget(key, 'timestamp_last_status_update'))
-                seconds_since_last_update = (current_time - last_update) / 1000
+                seconds_since_last_update = current_time - (last_update / 1000)
             except TypeError as err:
                 self.logger.info('Key %s with information %s has no '
                                  'appropriate timestamp_last_status_update '

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -112,8 +112,8 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             except:
                 # Why didn't we catch this?
                 self.logger.error('Encountered %s: %s when calling HSET. '
-                                    'Retrying in %s seconds.',
-                                    type(err).__name__, err, self.backoff)
+                                  'Retrying in %s seconds.',
+                                  type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
         return response
 
@@ -130,8 +130,8 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             except:
                 # Why didn't we catch this?
                 self.logger.error('Encountered %s: %s when calling SCAN. '
-                                    'Retrying in %s seconds.',
-                                    type(err).__name__, err, self.backoff)
+                                  'Retrying in %s seconds.',
+                                  type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
         return response
 
@@ -148,8 +148,8 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             except:
                 # Why didn't we catch this?
                 self.logger.error('Encountered %s: %s when calling TYPE. '
-                                    'Retrying in %s seconds.',
-                                    type(err).__name__, err, self.backoff)
+                                  'Retrying in %s seconds.',
+                                  type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
         return response
 
@@ -166,8 +166,8 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             except:
                 # Why didn't we catch this?
                 self.logger.error('Encountered %s: %s when calling HGET. '
-                                    'Retrying in %s seconds.',
-                                    type(err).__name__, err, self.backoff)
+                                  'Retrying in %s seconds.',
+                                  type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
         return response
 
@@ -184,8 +184,8 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
             except:
                 # Why didn't we catch this?
                 self.logger.error('Encountered %s: %s when calling HGETALL. '
-                                    'Retrying in %s seconds.',
-                                    type(err).__name__, err, self.backoff)
+                                  'Retrying in %s seconds.',
+                                  type(err).__name__, err, self.backoff)
                 time.sleep(self.backoff)
         return response
 

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -245,7 +245,7 @@ class TestJanitor(object):
 #        # which should raise a FileNotFoundError
 #        parameter_list = ["kubectl","get","pods"]
 #        _make_kubectl_call(parameter_list)
-#        
+#
 #        while True:
 #            try:
 #                break

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -246,7 +246,7 @@ class TestJanitor(object):
 
         # since these tests won't be run in a kiosk, kubectl shouldn't be installed,
         # which should raise a FileNotFoundError
-        parameter_list = ["kubectl","get","pods"]
+        parameter_list = ["kubectl", "get", "pods"]
         try:
             janitor._make_kubectl_call(parameter_list)
         except FileNotFoundError:

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -107,8 +107,8 @@ class DummyRedis(object):
             if 'malformed' in rhash:
                 return None
             if 'stale' in rhash:
-                return time.time() - 400000
-            return time.time()
+                return (time.time() - 400000) * 1000
+            return time.time() * 1000
         return None
 
     def hset(self, rhash, status, value):  # pylint: disable=W0613

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -238,3 +238,22 @@ class TestJanitor(object):
 
         # run triage_keys
         janitor.triage_keys()
+
+#    import subprocess
+#    def test__make_kubectl_call(self):
+#        # since these tests won't be run in a kiosk, kubectl shouldn't be installed,
+#        # which should raise a FileNotFoundError
+#        parameter_list = ["kubectl","get","pods"]
+#        _make_kubectl_call(parameter_list)
+#        
+#        while True:
+#            try:
+#                break
+#            except subprocess.CalledProcessError as err:
+#                # For some reason, we can't execute this command right now.
+#                # Keep trying until we can.
+#                self.logger.warning('Encountered %s: %s while executing with '
+#                                    'parameters: %s. Retrying in %s seconds...',
+#                                    parameter_list, type(err).__name__, err,
+#                                    self.backoff)
+#                time.sleep(self.backoff)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 redis==3.2.1
+kubernetes==9.0.0


### PR DESCRIPTION
The redis-janitor would sometimes hit a `CalledProcessError` while executing the `kill_pod()` method. It now logs and retries where it encounters that exception, the same behavior used in the other two functions that make system calls.

Please forgive the poor programming practice, but this branch is currently built to the `vanvalenlab/kiosk-redis-janitor:0.1` Docker image.