### PR TITLE
Fix scan_iter memory leak

### DIFF
--- a/redis-janitor.py
+++ b/redis-janitor.py
@@ -37,7 +37,7 @@ import logging.handlers
 import redis
 import kubernetes
 
-from redis_janitor import RedisJanitor
+import redis_janitor
 
 
 def initialize_logger(debug_mode=True):
@@ -78,12 +78,7 @@ if __name__ == '__main__':
         decode_responses=True,
         charset='utf-8')
 
-    kubernetes.config.load_incluster_config()
-
-    KUBE = kubernetes.client.CoreV1Api(
-        kubernetes.client.ApiClient())
-
-    janitor = RedisJanitor(redis_client=REDIS, kube_client=KUBE)
+    janitor = redis_janitor.RedisJanitor(redis_client=REDIS)
 
     while True:
         try:

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -38,24 +38,32 @@ import kubernetes.client
 
 class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
 
-    def __init__(self, redis_client, kube_client, backoff=3):
+    def __init__(self, redis_client, backoff=3):
         self.redis_client = redis_client
-        self.kube_client = kube_client
         self._repairs = 0
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.backoff = backoff
+
+    def get_core_v1_client(self):
+        """Returns Kubernetes API Client for CoreV1Api"""
+        t = timeit.default_timer()
+        kubernetes.config.load_incluster_config()
+        kube_client = kubernetes.client.CoreV1Api()
+        self.logger.debug('Created CoreV1Api client in %s seconds.',
+                          timeit.default_timer() - t)
+        return kube_client
 
     def kill_pod(self, pod_name, namespace):
         # delete the pod
         t = timeit.default_timer()
         try:
-            response = self.kube_client.delete_namespaced_pod(
+            kube_client = self.get_core_v1_client()
+            response = kube_client.delete_namespaced_pod(
                 pod_name, namespace, grace_period_seconds=0)
         except kubernetes.client.rest.ApiException as err:
-            self.logger.warning('Encountered %s: %s when calling '
-                                '`delete_namespaced_pod`. ',
-                                type(err).__name__, err)
-            raise err
+            self.logger.error('`delete_namespaced_pod` encountered %s: %s.',
+                              type(err).__name__, err)
+            return False
         self.logger.debug('Killed pod `%s` in namespace `%s` in %s seconds.',
                           pod_name, namespace, timeit.default_timer() - t)
         return response
@@ -63,12 +71,12 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
     def list_pod_for_all_namespaces(self):
         t = timeit.default_timer()
         try:
-            response = self.kube_client.list_pod_for_all_namespaces()
+            kube_client = self.get_core_v1_client()
+            response = kube_client.list_pod_for_all_namespaces()
         except kubernetes.client.rest.ApiException as err:
-            self.logger.error('Encountered %s: %s when calling '
-                              '`list_pod_for_all_namespaces`. ',
-                              type(err).__name__, err)
-            raise err
+            self.logger.error('`list_pod_for_all_namespaces` encountered '
+                              '%s: %s.', type(err).__name__, err)
+            return []
         self.logger.debug('Found %s pods in %s seconds.',
                           len(response.items), timeit.default_timer() - t)
         return response.items

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -89,10 +89,10 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
                 raise err
         return response
 
-    def scan_iter(self, match=None):
+    def scan_iter(self, match=None, count=None):
         while True:
             try:
-                response = self.redis_client.scan_iter(match=match)
+                response = self.redis_client.scan_iter(match=match, count=count)
                 break
             except (ConnectionError, redis.exceptions.ConnectionError) as err:
                 self.logger.warning('Encountered %s: %s when calling SCAN. '
@@ -225,7 +225,7 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
         pods = self.list_pod_for_all_namespaces()
         self.logger.info('Found %s pods.', len(pods))
 
-        for key in self.scan_iter():
+        for key in self.scan_iter(count=1000):
             if self._redis_type(key) == 'hash':
                 key_repaired = self.triage(key, pods)
                 num_repaired = int(key_repaired)

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -60,7 +60,7 @@ class DummyRedis(object):
             '{}_{}_{}'.format('other', self.status, 'x.zip'),
         ]
 
-    def scan_iter(self, match=None):
+    def scan_iter(self, match=None, count=None):
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
             raise redis.exceptions.ConnectionError('thrown on purpose')

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -30,7 +30,10 @@ from __future__ import print_function
 
 import time
 
+import pytest
+
 import redis
+import kubernetes
 
 from redis_janitor import janitors
 
@@ -41,7 +44,9 @@ class Bunch(object):
 
 
 class DummyRedis(object):
-    def __init__(self, prefix='predict', status='new', fail_tolerance=0):
+    def __init__(self, prefix='predict', status='new',
+                 fail_tolerance=0, hard_fail=False):
+        self.hard_fail = hard_fail
         self.fail_count = 0
         self.fail_tolerance = fail_tolerance
         self.prefix = '/'.join(x for x in prefix.split('/') if x)
@@ -61,6 +66,8 @@ class DummyRedis(object):
         ]
 
     def scan_iter(self, match=None, count=None):
+        if self.hard_fail:
+            raise Exception('thrown on purpose')
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
             raise redis.exceptions.ConnectionError('thrown on purpose')
@@ -89,12 +96,16 @@ class DummyRedis(object):
                         yield k
 
     def hmset(self, rhash, hvals):  # pylint: disable=W0613
+        if self.hard_fail:
+            raise Exception('thrown on purpose')
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
             raise redis.exceptions.ConnectionError('thrown on purpose')
         return hvals
 
     def hget(self, rhash, field):
+        if self.hard_fail:
+            raise Exception('thrown on purpose')
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
             raise redis.exceptions.ConnectionError('thrown on purpose')
@@ -116,12 +127,16 @@ class DummyRedis(object):
         return None
 
     def hset(self, rhash, status, value):  # pylint: disable=W0613
+        if self.hard_fail:
+            raise Exception('thrown on purpose')
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
             raise redis.exceptions.ConnectionError('thrown on purpose')
         return {status: value}
 
     def hgetall(self, rhash):  # pylint: disable=W0613
+        if self.hard_fail:
+            raise Exception('thrown on purpose')
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
             raise redis.exceptions.ConnectionError('thrown on purpose')
@@ -138,6 +153,8 @@ class DummyRedis(object):
         }
 
     def type(self, key):  # pylint: disable=W0613
+        if self.hard_fail:
+            raise Exception('thrown on purpose')
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
             raise redis.exceptions.ConnectionError('thrown on purpose')
@@ -146,10 +163,17 @@ class DummyRedis(object):
 
 class DummyKubernetes(object):
 
-    def delete_namespaced_pod(self, *args, **kwargs):
+    def __init__(self, fail=False):
+        self.fail = fail
+
+    def delete_namespaced_pod(self, pod_name, _, **kwargs):
+        if pod_name == 'fail':
+            raise kubernetes.client.rest.ApiException('thrown on purpose')
         return True
 
     def list_pod_for_all_namespaces(self, *args, **kwargs):
+        if self.fail:
+            raise kubernetes.client.rest.ApiException('thrown on purpose')
         return Bunch(items=[Bunch(status=Bunch(phase='Running'),
                                   metadata=Bunch(name='pod'))])
 
@@ -158,52 +182,93 @@ class TestJanitor(object):
 
     def test_hgetall(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        kube_client = DummyKubernetes()
-        janitor = janitors.RedisJanitor(redis_client, kube_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
 
         data = janitor.hgetall('redis_hash')
         assert data == redis_client.hgetall('redis_hash')
         assert janitor.redis_client.fail_count == redis_client.fail_tolerance
 
+        with pytest.raises(Exception):
+            redis_client = DummyRedis(hard_fail=True)
+            janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+            janitor.hgetall('redis_hash')
+
     def test__redis_type(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        kube_client = DummyKubernetes()
-        janitor = janitors.RedisJanitor(redis_client, kube_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
 
         data = janitor._redis_type('random_key')
         assert data == redis_client.type('random_key')
         assert janitor.redis_client.fail_count == redis_client.fail_tolerance
 
+        with pytest.raises(Exception):
+            redis_client = DummyRedis(hard_fail=True)
+            janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+            janitor._redis_type('random_key')
+
     def test_hset(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        kube_client = DummyKubernetes()
-        janitor = janitors.RedisJanitor(redis_client, kube_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
         janitor.hset('rhash', 'key', 'value')
         assert janitor.redis_client.fail_count == redis_client.fail_tolerance
 
+        with pytest.raises(Exception):
+            redis_client = DummyRedis(hard_fail=True)
+            janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+            janitor.hset('rhash', 'key', 'value')
+
     def test_hget(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        kube_client = DummyKubernetes()
-        janitor = janitors.RedisJanitor(redis_client, kube_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
         data = janitor.hget('rhash_new', 'status')
         assert data == 'new'
         assert janitor.redis_client.fail_count == redis_client.fail_tolerance
 
+        with pytest.raises(Exception):
+            redis_client = DummyRedis(hard_fail=True)
+            janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+            janitor.hget('rhash_new', 'status')
+
     def test_scan_iter(self):
         prefix = 'predict'
         redis_client = DummyRedis(fail_tolerance=2, prefix=prefix)
-        kube_client = DummyKubernetes()
-        janitor = janitors.RedisJanitor(redis_client, kube_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
         data = janitor.scan_iter(match=prefix)
         keys = [k for k in data]
         expected = [k for k in redis_client.keys() if k.startswith(prefix)]
         assert janitor.redis_client.fail_count == redis_client.fail_tolerance
         assert keys == expected
 
+        with pytest.raises(Exception):
+            redis_client = DummyRedis(hard_fail=True)
+            janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+            janitor.scan_iter(match=prefix)
+
+    def test_kill_pod(self):
+        redis_client = DummyRedis(fail_tolerance=2)
+        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+        janitor.get_core_v1_client = DummyKubernetes
+
+        assert janitor.kill_pod('pass', 'ns') is True
+        assert janitor.kill_pod('fail', 'ns') is False
+
+    def test_list_pod_for_all_namespaces(self):
+        redis_client = DummyRedis(fail_tolerance=2)
+        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+        janitor.get_core_v1_client = DummyKubernetes
+
+        items = janitor.list_pod_for_all_namespaces()
+        assert len(items) == 1 and items[0].metadata.name == 'pod'
+
+        janitor.get_core_v1_client = lambda: DummyKubernetes(fail=True)
+
+        items = janitor.list_pod_for_all_namespaces()
+        assert items == []
+
+
     def test_triage(self):
         redis_client = DummyRedis(fail_tolerance=0)
-        kube_client = DummyKubernetes()
-        janitor = janitors.RedisJanitor(redis_client, kube_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
 
         janitor.kill_pod = lambda x, y: True
 
@@ -242,8 +307,8 @@ class TestJanitor(object):
 
     def test_triage_keys(self):
         redis_client = DummyRedis(fail_tolerance=0)
-        kube_client = DummyKubernetes()
-        janitor = janitors.RedisJanitor(redis_client, kube_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+        janitor.get_core_v1_client = DummyKubernetes
 
         # monkey-patch kubectl commands
         janitor.kill_pod = lambda x: True

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -265,7 +265,6 @@ class TestJanitor(object):
         items = janitor.list_pod_for_all_namespaces()
         assert items == []
 
-
     def test_triage(self):
         redis_client = DummyRedis(fail_tolerance=0)
         janitor = janitors.RedisJanitor(redis_client, backoff=0.01)


### PR DESCRIPTION
Added a `count` parameter to the scan_iter call in order to limit the number of results fetched at once.

Additionally, the Kubernetes client initialization has been moved into a Janitor helper function.  This enables more of the inner workings of the code to be tested. Coverage is now 95%+.

Finally, this should resolve #11, as the janitor will neither fail nor retry on a `kubernetes.client.rest.ApiException`, but it will log the error, and return a non-usable value (false, or an empty list).  This way the janitor does not crash from the error, but will not get stuck in an infinite loop either.