### PR TITLE
Redis wrapper class and redis queue for processing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,7 @@ exclude_lines =
     raise NotImplementedError
 
 ignore_errors = True
-fail_under = 50
+fail_under = 80
 show_missing = True
 
 omit = **/*_test.py

--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ disable=
     too-few-public-methods,
     wildcard-import,
     mixed-indentation,
-    redefined-variable-type
+    redefined-variable-type,
+    useless-object-inheritance
 
 
 [REPORTS]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: false
-dist: trusty
+sudo: true
+dist: xenial
 
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ language: python
 
 python:
   # - 2.7
-  - 3.5
-  - 3.6
+  # - 3.5
+  # - 3.6
+  - 3.7
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: true
-dist: xenial
+sudo: false
+dist: trusty
 
 git:
   depth: false
@@ -7,10 +7,9 @@ git:
 language: python
 
 python:
-  - 3.7
-  # - 3.6
-  # - 3.5
-  # - 2.7
+  - 2.7
+  - 3.5
+  - 3.6
 
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ git:
 language: python
 
 python:
-  # - 2.7
-  # - 3.5
-  # - 3.6
   - 3.7
+  # - 3.6
+  # - 3.5
+  # - 2.7
 
 cache: pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-CMD ["python", "redis-janitor.py"]
+CMD ["/bin/sh", "-c", "python redis-janitor.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-FROM python:3.7-alpine
+FROM python:3.6-alpine
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,29 @@
-FROM python:3.6
+# Copyright 2016-2019 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/kiosk-redis-janitor/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+FROM python:3.7-alpine
 
 WORKDIR /usr/src/app
 
@@ -8,4 +33,4 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-CMD ["python", "redis-janitor.py"]
+CMD ["/bin/sh", "-c", "python", "redis-janitor.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN pip install -r requirements.txt
 
 COPY . .
 
-CMD ["/bin/sh", "-c", "python", "redis-janitor.py"]
+CMD ["python", "redis-janitor.py"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,3 @@ norecursedirs=
 # W503 line break occurred before a binary operator
 
 pep8ignore=* E731
-
-# Enable line length testing with maximum line length of 99
-pep8maxlinelength = 99

--- a/redis-janitor.py
+++ b/redis-janitor.py
@@ -44,7 +44,8 @@ def initialize_logger(debug_mode=True):
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
 
-    formatter = logging.Formatter('[%(asctime)s]:[%(levelname)s]:[%(name)s]: %(message)s')
+    formatter = logging.Formatter(
+        '[%(asctime)s]:[%(levelname)s]:[%(name)s]: %(message)s')
     console = logging.StreamHandler(stream=sys.stdout)
     console.setFormatter(formatter)
 

--- a/redis-janitor.py
+++ b/redis-janitor.py
@@ -68,6 +68,7 @@ def initialize_logger(debug_mode=True):
 
 if __name__ == '__main__':
     INTERVAL = int(os.getenv('INTERVAL', '20'))
+    QUEUE = os.getenv('QUEUE', 'predict')
 
     initialize_logger(os.getenv('DEBUG'))
 
@@ -77,7 +78,7 @@ if __name__ == '__main__':
         os.getenv('REDIS_HOST'),
         os.getenv('REDIS_PORT'))
 
-    janitor = redis_janitor.RedisJanitor(redis_client=REDIS)
+    janitor = redis_janitor.RedisJanitor(redis_client=REDIS, queue=QUEUE)
 
     while True:
         try:

--- a/redis-janitor.py
+++ b/redis-janitor.py
@@ -72,11 +72,9 @@ if __name__ == '__main__':
 
     _logger = logging.getLogger(__file__)
 
-    REDIS = redis.StrictRedis(
-        host=os.getenv('REDIS_HOST'),
-        port=os.getenv('REDIS_PORT'),
-        decode_responses=True,
-        charset='utf-8')
+    REDIS = redis_janitor.redis.RedisClient(
+        os.getenv('REDIS_HOST'),
+        os.getenv('REDIS_PORT'))
 
     janitor = redis_janitor.RedisJanitor(redis_client=REDIS)
 

--- a/redis_janitor/__init__.py
+++ b/redis_janitor/__init__.py
@@ -27,6 +27,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from redis_janitor import redis
+
 from redis_janitor.janitors import RedisJanitor
 
 del absolute_import

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -50,8 +50,7 @@ class RedisJanitor(object):
     def get_core_v1_client(self):
         """Returns Kubernetes API Client for CoreV1Api"""
         kubernetes.config.load_incluster_config()
-        kube_client = kubernetes.client.CoreV1Api()
-        return kube_client
+        return kubernetes.client.CoreV1Api()
 
     def kill_pod(self, pod_name, namespace):
         # delete the pod

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -92,7 +92,8 @@ class RedisJanitor(object):
             try:
                 pod = [p for p in all_pods if p.metadata.name == host][0]
             except IndexError:
-                self.logger.info('Pod %s is AWOL. Resetting record %s.', host, key)
+                self.logger.info('Pod %s not found. Resetting record `%s`.',
+                                 host, key)
                 self.redis_client.hset(key, 'status', 'new')
                 return True
 

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -35,7 +35,7 @@ import logging
 import kubernetes.client
 
 
-class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
+class RedisJanitor(object):
 
     def __init__(self, redis_client, backoff=3):
         self.redis_client = redis_client

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -33,6 +33,7 @@ import datetime
 import logging
 
 import pytz
+import dateutil.parser
 import kubernetes.client
 
 
@@ -122,10 +123,12 @@ class RedisJanitor(object):
             # has the key's status been updated in the last N seconds?
             timeout_seconds = 300
             try:
-                current_time = datetime.datetime.now(pytz.UTC).isoformat()
+                current_time = datetime.datetime.now(pytz.UTC)
                 updated_time = self.redis_client.hget(key, 'updated_at')
-                parse = lambda x: datetime.datetime.fromisoformat(x)
-                update_diff = parse(current_time) - parse(updated_time)
+                # TODO: `dateutil` deprecated by python 3.7 `fromisoformat`
+                # updated_time = datetime.datetime.fromisoformat(updated_time)
+                updated_time = dateutil.parser.parse(updated_time)
+                update_diff = current_time - updated_time
             except (TypeError, ValueError) as err:
                 self.logger.info('Key %s with information %s has no '
                                  'appropriate `updated_at` '

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -45,11 +45,8 @@ class RedisJanitor(object):  # pylint: disable=useless-object-inheritance
 
     def get_core_v1_client(self):
         """Returns Kubernetes API Client for CoreV1Api"""
-        t = timeit.default_timer()
         kubernetes.config.load_incluster_config()
         kube_client = kubernetes.client.CoreV1Api()
-        self.logger.debug('Created CoreV1Api client in %s seconds.',
-                          timeit.default_timer() - t)
         return kube_client
 
     def kill_pod(self, pod_name, namespace):

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -124,8 +124,7 @@ class RedisJanitor(object):
             try:
                 current_time = datetime.datetime.now(pytz.UTC).isoformat()
                 updated_time = self.redis_client.hget(key, 'updated_at')
-                isoformat = '%Y-%m-%dT%H:%M:%S.%f'
-                parse = lambda x: datetime.datetime.strptime(x, isoformat)
+                parse = lambda x: datetime.datetime.fromisoformat(x)
                 update_diff = parse(current_time) - parse(updated_time)
             except (TypeError, ValueError) as err:
                 self.logger.info('Key %s with information %s has no '

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -121,11 +121,10 @@ class RedisJanitor(object):
             # has the key's status been updated in the last N seconds?
             timeout_seconds = 300
             try:
-                fmt = '%b %d, %Y %H:%M:%S.%f'
-                current_time = datetime.datetime.now(datetime.timezone.utc)
-                current_time = current_time.strftime(fmt)
+                current_time = datetime.datetime.utcnow().isoformat()
                 updated_time = self.redis_client.hget(key, 'updated_at')
-                parse = lambda x: datetime.datetime.strptime(x, fmt)
+                isoformat = '%Y-%m-%dT%H:%M:%S.%f'
+                parse = lambda x: datetime.datetime.strptime(x, isoformat)
                 update_diff = parse(current_time) - parse(updated_time)
             except (TypeError, ValueError) as err:
                 self.logger.info('Key %s with information %s has no '

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -113,18 +113,18 @@ class RedisJanitor(object):
                 fmt = '%b %d, %Y %H:%M:%S.%f'
                 current_time = datetime.datetime.now(datetime.timezone.utc)
                 current_time = current_time.strftime(fmt)
-                updated_time = self.redis_client.hget(key, 'last_updated')
+                updated_time = self.redis_client.hget(key, 'updated_at')
                 parse = lambda x: datetime.datetime.strptime(x, fmt)
                 update_diff = parse(current_time) - parse(updated_time)
             except (TypeError, ValueError) as err:
                 self.logger.info('Key %s with information %s has no '
-                                 'appropriate `last_updated` '
+                                 'appropriate `updated_at` '
                                  'field. %s: %s', key,
                                  self.redis_client.hgetall(key),
                                  type(err).__name__, err)
                 return False
 
-            if update_diff.seconds >= timeout_seconds:
+            if update_diff.total_seconds() >= timeout_seconds:
                 # This entry has not been updated in at least `timeout_seconds`
                 # Assume it has died, and reset the status
                 self.logger.info('Key `%s` has not been updated in %s seconds.'

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -32,6 +32,7 @@ import timeit
 import datetime
 import logging
 
+import pytz
 import kubernetes.client
 
 
@@ -121,7 +122,7 @@ class RedisJanitor(object):
             # has the key's status been updated in the last N seconds?
             timeout_seconds = 300
             try:
-                current_time = datetime.datetime.utcnow().isoformat()
+                current_time = datetime.datetime.now(pytz.UTC).isoformat()
                 updated_time = self.redis_client.hget(key, 'updated_at')
                 isoformat = '%Y-%m-%dT%H:%M:%S.%f'
                 parse = lambda x: datetime.datetime.strptime(x, isoformat)

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -35,12 +35,12 @@ import kubernetes
 from redis_janitor import janitors
 
 
-class Bunch(object):  # pylint: disable=useless-object-inheritance
+class Bunch(object):
     def __init__(self, **kwds):
         self.__dict__.update(kwds)
 
 
-class DummyRedis(object):  # pylint: disable=useless-object-inheritance
+class DummyRedis(object):
     def __init__(self, prefix='predict', status='new',
                  fail_tolerance=0, hard_fail=False):
         self.hard_fail = hard_fail
@@ -117,7 +117,7 @@ class DummyRedis(object):  # pylint: disable=useless-object-inheritance
         return 'hash'
 
 
-class DummyKubernetes(object):  # pylint: disable=useless-object-inheritance
+class DummyKubernetes(object):
 
     def __init__(self, fail=False):
         self.fail = fail
@@ -134,7 +134,7 @@ class DummyKubernetes(object):  # pylint: disable=useless-object-inheritance
                                   metadata=Bunch(name='pod'))])
 
 
-class TestJanitor(object):  # pylint: disable=useless-object-inheritance
+class TestJanitor(object):
 
     def test_kill_pod(self):
         redis_client = DummyRedis(fail_tolerance=2)

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 
 import datetime
 
+import pytz
 import kubernetes
 
 from redis_janitor import janitors
@@ -95,12 +96,10 @@ class DummyRedis(object):
         elif field == 'updated_at':
             if 'malformed' in rhash:
                 return None
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(pytz.UTC)
             if 'stale' in rhash:
-                return datetime.datetime.strftime(
-                    now - datetime.timedelta(hours=1), '%Y-%m-%dT%H:%M:%S.%f')
-            return datetime.datetime.strftime(
-                now - datetime.timedelta(minutes=1), '%Y-%m-%dT%H:%M:%S.%f')
+                return (now - datetime.timedelta(hours=1)).isoformat(' ')
+            return (now - datetime.timedelta(minutes=1)).isoformat(' ')
         return None
 
     def hset(self, rhash, status, value):  # pylint: disable=W0613

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -167,10 +167,8 @@ class TestJanitor(object):
         def pod(key):
             status = 'Failed' if 'failed' in key else 'Running'
             name = 'good_pod' if 'good' in key else 'bad_pod'
-            return [
-                Bunch(metadata=Bunch(name=name),
-                status=Bunch(phase=status))
-            ]
+            return [Bunch(metadata=Bunch(name=name),
+                          status=Bunch(phase=status))]
 
         # test end point statuses
         assert janitor.triage('goodkey_failed', pod('goodkey_failed')) is True
@@ -185,10 +183,8 @@ class TestJanitor(object):
         assert janitor.triage('badkey_inprogress', []) is True
 
         # test in progress with status != Running
-        pods = [
-            Bunch(metadata=Bunch(name='good_pod'),
-            status=Bunch(phase='Failed'))
-        ]
+        pods = [Bunch(metadata=Bunch(name='good_pod'),
+                      status=Bunch(phase='Failed'))]
         assert janitor.triage('goodkey_inprogress', pods) is True
 
         # test in progress with status = Running with stale update time

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -167,7 +167,10 @@ class TestJanitor(object):
         def pod(key):
             status = 'Failed' if 'failed' in key else 'Running'
             name = 'good_pod' if 'good' in key else 'bad_pod'
-            return [Bunch(metadata=Bunch(name=name), status=Bunch(phase=status))]
+            return [
+                Bunch(metadata=Bunch(name=name),
+                status=Bunch(phase=status))
+            ]
 
         # test end point statuses
         assert janitor.triage('goodkey_failed', pod('goodkey_failed')) is True
@@ -182,7 +185,10 @@ class TestJanitor(object):
         assert janitor.triage('badkey_inprogress', []) is True
 
         # test in progress with status != Running
-        pods = [Bunch(metadata=Bunch(name='good_pod'), status=Bunch(phase='Failed'))]
+        pods = [
+            Bunch(metadata=Bunch(name='good_pod'),
+            status=Bunch(phase='Failed'))
+        ]
         assert janitor.triage('goodkey_inprogress', pods) is True
 
         # test in progress with status = Running with stale update time

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -62,6 +62,12 @@ class DummyRedis(object):
             return (k for k in self.keys if k.startswith(match[:-1]))
         return (k for k in self.keys)
 
+    def lrem(self, *_, **__):
+        return True
+
+    def lpush(self, *_, **__):
+        return True
+
     def expected_keys(self, suffix=None):
         for k in self.keys:
             v = k.split('_')
@@ -138,7 +144,7 @@ class TestJanitor(object):
 
     def test_kill_pod(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, 'q', backoff=0.01)
         janitor.get_core_v1_client = DummyKubernetes
         assert janitor.kill_pod('pass', 'ns') is True
 
@@ -147,7 +153,7 @@ class TestJanitor(object):
 
     def test_list_pod_for_all_namespaces(self):
         redis_client = DummyRedis(fail_tolerance=2)
-        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, 'q', backoff=0.01)
         janitor.get_core_v1_client = DummyKubernetes
 
         items = janitor.list_pod_for_all_namespaces()
@@ -160,7 +166,7 @@ class TestJanitor(object):
 
     def test_triage(self):
         redis_client = DummyRedis(fail_tolerance=0)
-        janitor = janitors.RedisJanitor(redis_client, backoff=0)
+        janitor = janitors.RedisJanitor(redis_client, 'q', backoff=0)
 
         janitor.kill_pod = lambda x, y: True
 
@@ -201,7 +207,7 @@ class TestJanitor(object):
 
     def test_triage_keys(self):
         redis_client = DummyRedis(fail_tolerance=0)
-        janitor = janitors.RedisJanitor(redis_client, backoff=0.01)
+        janitor = janitors.RedisJanitor(redis_client, 'q', backoff=0.01)
         janitor.get_core_v1_client = DummyKubernetes
 
         # monkey-patch kubectl commands

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -86,7 +86,7 @@ class DummyRedis(object):
                 return None
             else:
                 return 'bad_pod'
-        elif field == 'last_updated':
+        elif field == 'updated_at':
             if 'malformed' in rhash:
                 return None
             now = datetime.datetime.now(datetime.timezone.utc)
@@ -193,7 +193,7 @@ class TestJanitor(object):
         assert janitor.triage('goodkey_inprogress',
                               pod('goodkey_inprogress')) is False
 
-        # test no `last_updated`
+        # test no `updated_at`
         assert janitor.triage('goodmalformed_inprogress',
                               pod('goodmalformed_inprogress')) is False
 

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -95,12 +95,12 @@ class DummyRedis(object):
         elif field == 'updated_at':
             if 'malformed' in rhash:
                 return None
-            now = datetime.datetime.now(datetime.timezone.utc)
+            now = datetime.datetime.utcnow()
             if 'stale' in rhash:
                 return datetime.datetime.strftime(
-                    now - datetime.timedelta(hours=1), '%b %d, %Y %H:%M:%S.%f')
+                    now - datetime.timedelta(hours=1), '%Y-%m-%dT%H:%M:%S.%f')
             return datetime.datetime.strftime(
-                now - datetime.timedelta(minutes=1), '%b %d, %Y %H:%M:%S.%f')
+                now - datetime.timedelta(minutes=1), '%Y-%m-%dT%H:%M:%S.%f')
         return None
 
     def hset(self, rhash, status, value):  # pylint: disable=W0613

--- a/redis_janitor/redis.py
+++ b/redis_janitor/redis.py
@@ -1,0 +1,71 @@
+# Copyright 2016-2019 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/kiosk-redis-janitor/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Fault tolerant RedisClient wrapper class"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import time
+import logging
+
+import redis
+
+
+class RedisClient(object):  # pylint: disable=useless-object-inheritance
+
+    def __init__(self, host, port, backoff=1):
+        self.logger = logging.getLogger(str(self.__class__.__name__))
+        self.backoff = backoff
+        self._redis = self._get_redis_client(host=host, port=port)
+
+    def _get_redis_client(self, host, port):  # pylint: disable=R0201
+        return redis.StrictRedis(
+            host=host, port=port,
+            decode_responses=True,
+            charset='utf-8')
+
+    def __getattr__(self, name):
+        redis_function = getattr(self._redis, name)
+
+        def wrapper(*args, **kwargs):
+            while True:
+                try:
+                    return redis_function(*args, **kwargs)
+                except redis.exceptions.ConnectionError as err:
+                    values = list(args) + list(kwargs.values())
+                    self.logger.warning('Encountered %s: %s when calling '
+                                        '`%s %s`. Retrying in %s seconds.',
+                                        type(err).__name__, err,
+                                        str(name).upper(),
+                                        ' '.join(values), self.backoff)
+                    time.sleep(self.backoff)
+                except Exception as err:
+                    self.logger.error('Unexpected %s: %s when calling %s.',
+                                      type(err).__name__, err,
+                                      str(name).upper())
+                    raise err
+
+        return wrapper

--- a/redis_janitor/redis.py
+++ b/redis_janitor/redis.py
@@ -34,7 +34,7 @@ import logging
 import redis
 
 
-class RedisClient(object):  # pylint: disable=useless-object-inheritance
+class RedisClient(object):
 
     def __init__(self, host, port, backoff=1):
         self.logger = logging.getLogger(str(self.__class__.__name__))

--- a/redis_janitor/redis_test.py
+++ b/redis_janitor/redis_test.py
@@ -1,0 +1,80 @@
+# Copyright 2016-2019 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/kiosk-redis-janitor/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for RedisClient wrapper class"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import random
+
+import redis
+import pytest
+
+import redis_janitor
+
+
+class DummyRedis(object):  # pylint: disable=useless-object-inheritance
+    def __init__(self, fail_tolerance=0, hard_fail=False):
+        self.fail_count = 0
+        self.fail_tolerance = fail_tolerance
+        self.hard_fail = hard_fail
+
+    def get_fail_count(self):
+        if self.hard_fail:
+            raise AssertionError('thrown on purpose')
+        if self.fail_count < self.fail_tolerance:
+            self.fail_count += 1
+            raise redis.exceptions.ConnectionError('thrown on purpose')
+        return self.fail_count
+
+
+class TestRedis(object):  # pylint: disable=useless-object-inheritance
+
+    def test_redis_client(self):  # pylint: disable=R0201
+        fails = random.randint(1, 3)
+        RedisClient = redis_janitor.redis.RedisClient
+
+        # monkey patch _get_redis_client function to use DummyRedis client
+        def _get_redis_client(*args, **kwargs):  # pylint: disable=W0613
+            return DummyRedis(fail_tolerance=fails)
+
+        RedisClient._get_redis_client = _get_redis_client
+
+        client = RedisClient(host='host', port='port', backoff=0)
+        assert client.get_fail_count() == fails
+
+        with pytest.raises(AttributeError):
+            client.unknown_function()
+
+        # test that other exceptions will raise.
+        def _get_redis_client_bad(*args, **kwargs):  # pylint: disable=W0613
+            return DummyRedis(fail_tolerance=fails, hard_fail=True)
+
+        RedisClient._get_redis_client = _get_redis_client_bad
+
+        client = RedisClient(host='host', port='port', backoff=0)
+        with pytest.raises(AssertionError):
+            client.get_fail_count()

--- a/redis_janitor/redis_test.py
+++ b/redis_janitor/redis_test.py
@@ -36,7 +36,7 @@ import pytest
 import redis_janitor
 
 
-class DummyRedis(object):  # pylint: disable=useless-object-inheritance
+class DummyRedis(object):
     def __init__(self, fail_tolerance=0, hard_fail=False):
         self.fail_count = 0
         self.fail_tolerance = fail_tolerance
@@ -51,7 +51,7 @@ class DummyRedis(object):  # pylint: disable=useless-object-inheritance
         return self.fail_count
 
 
-class TestRedis(object):  # pylint: disable=useless-object-inheritance
+class TestRedis(object):
 
     def test_redis_client(self):  # pylint: disable=R0201
         fails = random.randint(1, 3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 redis==3.2.1
 kubernetes==9.0.0
+pytz==2019.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 redis==3.2.1
 kubernetes==9.0.0
 pytz==2019.1
+python-dateutil==2.8.0


### PR DESCRIPTION
Added a general Redis wrapper to remove all the named functions wrap in a try/catch.

Additionally, when a key is reset, also add it to the work queue.

Use `python-dateutil` to parse the ISO format datetimes.

standardize PEP8

update base image to `python:3.6-alpine`