### PR TITLE
Allow environment variable switches for some types of custodial work

### DIFF
--- a/redis-janitor.py
+++ b/redis-janitor.py
@@ -31,11 +31,8 @@ import os
 import sys
 import time
 import logging
-import traceback
 import logging.handlers
-
-import redis
-import kubernetes
+import traceback
 
 import redis_janitor
 
@@ -69,6 +66,7 @@ def initialize_logger(debug_mode=True):
 if __name__ == '__main__':
     INTERVAL = int(os.getenv('INTERVAL', '20'))
     QUEUE = os.getenv('QUEUE', 'predict')
+    STALE_TIME = os.getenv('STALE_TIME', '0')
 
     initialize_logger(os.getenv('DEBUG'))
 
@@ -78,7 +76,10 @@ if __name__ == '__main__':
         os.getenv('REDIS_HOST'),
         os.getenv('REDIS_PORT'))
 
-    janitor = redis_janitor.RedisJanitor(redis_client=REDIS, queue=QUEUE)
+    janitor = redis_janitor.RedisJanitor(
+        redis_client=REDIS,
+        queue=QUEUE,
+        stale_time=STALE_TIME)
 
     while True:
         try:

--- a/redis-janitor.py
+++ b/redis-janitor.py
@@ -67,6 +67,7 @@ if __name__ == '__main__':
     INTERVAL = int(os.getenv('INTERVAL', '20'))
     QUEUE = os.getenv('QUEUE', 'predict')
     STALE_TIME = os.getenv('STALE_TIME', '0')
+    RESTART_FAILURES = os.getenv('RESTART_FAILURES', 'false').lower() == 'true'
 
     initialize_logger(os.getenv('DEBUG'))
 
@@ -79,7 +80,8 @@ if __name__ == '__main__':
     janitor = redis_janitor.RedisJanitor(
         redis_client=REDIS,
         queue=QUEUE,
-        stale_time=STALE_TIME)
+        stale_time=STALE_TIME,
+        restart_failures=RESTART_FAILURES)
 
     while True:
         try:

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -169,10 +169,7 @@ class RedisJanitor(object):
         return False
 
     def triage_keys(self):
-        # or, 1,000 reasons to restart a key
         repairs = 0
-
-        # get list of all pods
         pods = self.list_pod_for_all_namespaces()
         pod_dict = {p.metadata.name: p for p in pods}
         self.logger.info('Found %s pods.', len(pods))


### PR DESCRIPTION
Use `STALE_TIME` to define how many seconds since last update requires a reset.  if < 0, than stale cleanup is disabled.

Use `RESTART_FAILURES` to reset keys that end up with a `failed` status.