### PR TITLE
Check if the pod is valid as a shortcut to STALE_TIME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /usr/src/app
 
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -82,7 +82,9 @@ if __name__ == '__main__':
         queue=QUEUE,
         stale_time=STALE_TIME)
 
-    _logger.info('Janitor Initialized.')
+    _logger.info('Janitor initialized. '
+                 'Cleaning queue `%s` every `%s` seconds.',
+                 QUEUE, INTERVAL)
 
     while True:
         try:

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -74,8 +74,8 @@ if __name__ == '__main__':
     _logger = logging.getLogger(__file__)
 
     REDIS = redis_janitor.redis.RedisClient(
-        decouple.config('REDIS_HOST'),
-        decouple.config('REDIS_PORT'))
+        decouple.config('REDIS_HOST', default='redis-master'),
+        decouple.config('REDIS_PORT', default=6379, cast=int))
 
     janitor = redis_janitor.RedisJanitor(
         redis_client=REDIS,

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -27,12 +27,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-import sys
-import time
-import signal
 import logging
 import logging.handlers
+import signal
+import sys
+import time
 import traceback
 
 import decouple

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -38,24 +38,6 @@ import traceback
 import redis_janitor
 
 
-class GracefulDeath:
-    """Catch signals to allow graceful shutdown.
-
-    Adapted from: https://stackoverflow.com/questions/18499497
-    """
-
-    def __init__(self):
-        self.signum = None
-        self.kill_now = False
-        self.logger = logging.getLogger(str(self.__class__.__name__))
-        signal.signal(signal.SIGINT, self.handle_signal)
-        signal.signal(signal.SIGTERM, self.handle_signal)
-
-    def handle_signal(self, signum, frame):  # pylint: disable=unused-argument
-        self.signum = signum
-        self.kill_now = True
-        self.logger.debug('Received signal `%s` and frame `%s`', signum, frame)
-
 
 def initialize_logger(debug_mode=True):
     logger = logging.getLogger()
@@ -91,7 +73,6 @@ if __name__ == '__main__':
     STALE_TIME = os.getenv('STALE_TIME', '600')
     RESTART_FAILURES = os.getenv('RESTART_FAILURES', 'false').lower() == 'true'
 
-    sighandler = GracefulDeath()
 
     _logger = logging.getLogger(__file__)
 
@@ -110,8 +91,6 @@ if __name__ == '__main__':
     while True:
         try:
             janitor.clean()
-            if sighandler.kill_now:
-                break
             time.sleep(INTERVAL)
         except Exception as err:  # pylint: disable=broad-except
             _logger.critical('Fatal Error: %s: %s', type(err).__name__, err)

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -35,8 +35,9 @@ import logging
 import logging.handlers
 import traceback
 
-import redis_janitor
+import decouple
 
+import redis_janitor
 
 
 def initialize_logger(debug_mode=True):
@@ -66,18 +67,17 @@ def initialize_logger(debug_mode=True):
 
 
 if __name__ == '__main__':
-    initialize_logger(os.getenv('DEBUG'))
+    initialize_logger(decouple.config('DEBUG', default=True, cast=bool))
 
-    INTERVAL = int(os.getenv('INTERVAL', '20'))
-    QUEUE = os.getenv('QUEUE', 'predict')
-    STALE_TIME = os.getenv('STALE_TIME', '600')
-
+    INTERVAL = decouple.config('INTERVAL', default=20, cast=int)
+    QUEUE = decouple.config('QUEUE', default='predict')
+    STALE_TIME = decouple.config('STALE_TIME', default='600', cast=int)
 
     _logger = logging.getLogger(__file__)
 
     REDIS = redis_janitor.redis.RedisClient(
-        os.getenv('REDIS_HOST'),
-        os.getenv('REDIS_PORT'))
+        decouple.config('REDIS_HOST'),
+        decouple.config('REDIS_PORT'))
 
     janitor = redis_janitor.RedisJanitor(
         redis_client=REDIS,

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -71,7 +71,6 @@ if __name__ == '__main__':
     INTERVAL = int(os.getenv('INTERVAL', '20'))
     QUEUE = os.getenv('QUEUE', 'predict')
     STALE_TIME = os.getenv('STALE_TIME', '600')
-    RESTART_FAILURES = os.getenv('RESTART_FAILURES', 'false').lower() == 'true'
 
 
     _logger = logging.getLogger(__file__)
@@ -83,8 +82,7 @@ if __name__ == '__main__':
     janitor = redis_janitor.RedisJanitor(
         redis_client=REDIS,
         queue=QUEUE,
-        stale_time=STALE_TIME,
-        restart_failures=RESTART_FAILURES)
+        stale_time=STALE_TIME)
 
     _logger.info('Janitor Initialized.')
 

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -83,8 +83,8 @@ if __name__ == '__main__':
         stale_time=STALE_TIME)
 
     _logger.info('Janitor initialized. '
-                 'Cleaning queue `%s` every `%s` seconds.',
-                 QUEUE, INTERVAL)
+                 'Cleaning queues `%s` and `%s:*` every `%s` seconds.',
+                 janitor.queue, janitor.processing_queue, INTERVAL)
 
     while True:
         try:

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -29,7 +29,6 @@ from __future__ import print_function
 
 import logging
 import logging.handlers
-import signal
 import sys
 import time
 import traceback

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -105,12 +105,13 @@ if __name__ == '__main__':
         stale_time=STALE_TIME,
         restart_failures=RESTART_FAILURES)
 
+    _logger.info('Janitor Initialized.')
+
     while True:
         try:
             janitor.clean()
             if sighandler.kill_now:
                 break
-            _logger.debug('Sleeping for %s seconds.', INTERVAL)
             time.sleep(INTERVAL)
         except Exception as err:  # pylint: disable=broad-except
             _logger.critical('Fatal Error: %s: %s', type(err).__name__, err)

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -192,15 +192,31 @@ class RedisJanitor(object):
     def clean_key(self, key):
         hvals = self.redis_client.hgetall(key)
 
-        # is_valid_pod = self.is_valid_pod(self.cleaning_queue.split(':')[-1])
+        pod_name = self.cleaning_queue.split(':')[-1]
+
+        is_valid_pod = self.is_valid_pod(pod_name)
         is_stale = self.is_stale_update_time(hvals.get('updated_at'))
 
-        # if is_valid_pod and not is_stale:
-        if not is_stale:
+        if is_valid_pod and not is_stale:  # pylint: disable=R1705
             return False
 
-        self.logger.info('Key `%s` in queue `%s` was last updated at `%s`.',
-                         key, self.cleaning_queue, hvals.get('updated_at'))
+        elif is_stale and not is_valid_pod:
+            self.logger.warning('Key `%s` in queue `%s` was last updated at '
+                                '`%s` and pod `%s` is still alive.',
+                                key, self.cleaning_queue,
+                                hvals.get('updated_at'), pod_name)
+            # self.kill_pod(pod_name, self.namespace)
+
+        elif not is_stale and not is_valid_pod:
+            self.logger.info('Key `%s` in queue `%s` was last updated by pod '
+                             '`%s`, but that pod does not exist.',
+                             key, self.cleaning_queue, pod_name)
+
+        else:
+            self.logger.info('Key `%s` in queue `%s` was last updated at `%s` '
+                             'by pod `%s` which no longer exists.',
+                             key, self.cleaning_queue,
+                             hvals.get('updated_at'), pod_name)
 
         key_status = hvals.get('status')
 

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -166,7 +166,7 @@ class RedisJanitor(object):
                              ' a `datetime.datetime` instance got %s.' %
                              type(self.pods_updated_at).__name__)
         else:
-            diff = self.pods_updated_at - datetime.datetime.now(pytz.UTC)
+            diff = datetime.datetime.now(pytz.UTC) - self.pods_updated_at
             if diff.total_seconds() > self.pod_refresh_interval:
                 self._update_pods()
 

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -46,7 +46,6 @@ class RedisJanitor(object):
                  namespace='default',
                  backoff=3,
                  stale_time=600,  # 10 minutes
-                 restart_failures=False,
                  failure_stale_seconds=60,
                  pod_refresh_interval=5,):
         self.redis_client = redis_client
@@ -55,7 +54,6 @@ class RedisJanitor(object):
         self.queue = str(queue).lower()
         self.namespace = namespace
         self.stale_time = int(stale_time)
-        self.restart_failures = restart_failures
         self.failure_stale_seconds = failure_stale_seconds
         self.pod_refresh_interval = int(pod_refresh_interval)
 

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -305,20 +305,6 @@ class TestJanitor(object):
         # test status `done`
         assert janitor.clean_key('predict:done') is False
 
-        # test status `failed` without `restart_failures`
-        janitor = self.get_client(restart_failures=False)
-        janitor.cleaning_queue = 'processing-q:pod'
-        assert janitor.clean_key('goodkey:failed') is False
-        # test status `failed` with `restart_failures` but fresh `updated_at`
-        janitor = self.get_client(restart_failures=True,
-                                  failure_stale_seconds=5)
-        janitor.cleaning_queue = 'processing-q:pod'
-        assert janitor.clean_key('goodkey:failed') is False
-        assert janitor.clean_key('stalekey:failed') is True
-
-        # test `updated_by` in whitelist
-        assert janitor.clean_key('whitelist-stale:inprogress') is True
-
         janitor = self.get_client(stale_time=60)
         janitor.cleaning_queue = 'processing-q:pod'
         assert janitor.clean_key('goodkeystale:inprogress') is True

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -329,6 +329,14 @@ class TestJanitor(object):
         # test no `updated_at`
         assert janitor.clean_key('goodmalformed:inprogress') is False
 
+        # test pod is not found
+        janitor.cleaning_queue = 'processing-q:bad'
+        assert janitor.clean_key('goodkey:inprogress') is True
+
+        # test pod is not found and stale
+        janitor.cleaning_queue = 'processing-q:bad'
+        assert janitor.clean_key('stalekey:inprogress') is True
+
     def test_clean(self):
         queue = 'q'
         janitor = self.get_client(queue=queue)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ redis==3.2.1
 kubernetes==9.0.0
 pytz==2019.1
 python-dateutil==2.8.0
+python-decouple>=3.1,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ redis==3.2.1
 kubernetes==9.0.0
 pytz==2019.1
 python-dateutil==2.8.0
-python-decouple>=3.1,<4
+python-decouple==3.1


### PR DESCRIPTION
Addresses a couple issues:

* Uses `python-decouple` to parse environment variables
* Removes the deprecated `restart_failures` parameter
* Re-introduces the `is_valid_pod` check
* Removes GracefulDeath as it is unnecessary
* removes the pip cache from the docker image.