### PR TITLE
reset connection_pool and retry on ReadOnlyError

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,6 @@ norecursedirs=
 # W503 line break occurred before a binary operator
 
 pep8ignore=* E731
+
+# Enable line length testing with maximum line length of 85
+pep8maxlinelength = 85

--- a/redis_janitor/redis.py
+++ b/redis_janitor/redis.py
@@ -51,21 +51,27 @@ class RedisClient(object):
         redis_function = getattr(self._redis, name)
 
         def wrapper(*args, **kwargs):
+            values = list(args) + list(kwargs.values())
             while True:
                 try:
                     return redis_function(*args, **kwargs)
                 except redis.exceptions.ConnectionError as err:
-                    values = list(args) + list(kwargs.values())
                     self.logger.warning('Encountered %s: %s when calling '
                                         '`%s %s`. Retrying in %s seconds.',
                                         type(err).__name__, err,
                                         str(name).upper(),
                                         ' '.join(values), self.backoff)
                     time.sleep(self.backoff)
+                except redis.exceptions.ReadOnlyError as err:
+                    self.logger.warning('Encountered `READONLYERROR: %s` '
+                                        'Resetting connection and retrying '
+                                        'in %s seconds.', err, self.backoff)
+                    self._redis.connection_pool.reset()
+                    time.sleep(self.backoff)
                 except Exception as err:
-                    self.logger.error('Unexpected %s: %s when calling %s.',
+                    self.logger.error('Unexpected %s: %s when calling `%s %s`.',
                                       type(err).__name__, err,
-                                      str(name).upper())
+                                      str(name).upper(), ' '.join(values))
                     raise err
 
         return wrapper


### PR DESCRIPTION
If attempting to write data to Redis using a connection to a `redis-ha` slave, a `ReadOnlyError` will be encountered.  This PR will catch the error, reset the connection using `connection_pool.reset`, and retry after `backoff` seconds.  Hopefully this will eventually use a connection that has write access.

Ideally, the client will immediately look up the master address, but I was unable to fix this in the short term.