### PR TITLE
Update the Redis client wrapper with Sentinel support

### DIFF
--- a/clean-redis.py
+++ b/clean-redis.py
@@ -82,9 +82,9 @@ if __name__ == '__main__':
         queue=QUEUE,
         stale_time=STALE_TIME)
 
-    _logger.info('Janitor initialized. '
-                 'Cleaning queues `%s` and `%s:*` every `%s` seconds.',
-                 janitor.queue, janitor.processing_queue, INTERVAL)
+    queues = ' and '.join('`%s:*`' % q for q in janitor.processing_queues)
+    _logger.info('Janitor initialized. Cleaning queues `%s` and %s every %ss.',
+                 janitor.queue, queues, INTERVAL)
 
     while True:
         try:

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,6 @@ norecursedirs=
 # W503 line break occurred before a binary operator
 
 pep8ignore=* E731
+
+# Enable line length testing with maximum line length of 85
+pep8maxlinelength = 85

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -248,7 +248,6 @@ class RedisJanitor(object):
                              updated_seconds, self.pods[pod_name].status.phase)
         return True
 
-
     def clean_key(self, key):
         required_keys = [
             'status',

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -195,7 +195,12 @@ class RedisJanitor(object):
         return update_diff.total_seconds() >= stale_time
 
     def clean_key(self, key):
-        hvals = self.redis_client.hgetall(key)
+        required_keys = [
+            'status',
+            'updated_at',
+        ]
+        res = self.redis_client.hmget(key, *required_keys)
+        hvals = {k: v for k, v in zip(required_keys, res)}
 
         pod_name = self.cleaning_queue.split(':')[-1]
 

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -63,7 +63,11 @@ class RedisJanitor(object):
 
         # attributes for managing pod state
         self.whitelisted_pods = ['zip-consumer']
-        self.valid_pod_phases = {'Running', 'Pending'}
+        self.valid_pod_phases = {
+            'Running',
+            # 'Pending',
+            # 'ContainerCreating'
+        }
 
         self.total_repairs = 0
         self.processing_queues = [
@@ -177,7 +181,11 @@ class RedisJanitor(object):
 
     def is_valid_pod(self, pod_name):
         self.update_pods()  # only updates if stale
-        is_valid = pod_name in self.pods
+        is_valid = False
+        if pod_name in self.pods:
+            pod_phase = self.pods[pod_name].status.phase
+            if pod_phase in self.valid_pod_phases:
+                is_valid = True
         return is_valid
 
     def is_stale_update_time(self, updated_time, stale_time=None):

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -140,7 +140,7 @@ class RedisJanitor(object):
         start = timeit.default_timer()
         res = self.redis_client.lrem(self.cleaning_queue, 1, redis_key)
         if res:
-            self.logger.debug('Removed key `%s` from %s` in %s seconds.',
+            self.logger.debug('Removed key `%s` from `%s` in %s seconds.',
                               redis_key, self.cleaning_queue,
                               timeit.default_timer() - start)
         else:
@@ -158,6 +158,9 @@ class RedisJanitor(object):
             self.logger.debug('Pushed key `%s` to `%s` in %s seconds.',
                               redis_key, source_queue,
                               timeit.default_timer() - start)
+        else:
+            self.logger.warning('Tried to repair key %s but it was no longer '
+                                'in %s', redis_key, self.cleaning_queue)
         return is_removed
 
     def _update_pods(self):

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -152,7 +152,7 @@ class RedisJanitor(object):
             source_queue = source_queue.split('processing-')[-1]
             self.redis_client.lpush(source_queue, redis_key)
             self.logger.debug('Pushed key `%s` to `%s` in %s seconds.',
-                              redis_key, self.queue,
+                              redis_key, source_queue,
                               timeit.default_timer() - start)
         return is_removed
 

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -148,7 +148,9 @@ class RedisJanitor(object):
         is_removed = self.remove_key_from_queue(redis_key)
         if is_removed:
             start = timeit.default_timer()
-            self.redis_client.lpush(self.queue, redis_key)
+            source_queue = self.cleaning_queue.split(':')[0]
+            source_queue = source_queue.split('processing-')[-1]
+            self.redis_client.lpush(source_queue, redis_key)
             self.logger.debug('Pushed key `%s` to `%s` in %s seconds.',
                               redis_key, self.queue,
                               timeit.default_timer() - start)

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -222,17 +222,17 @@ class RedisJanitor(object):
             return False  # this is too fresh for our pod data
 
         if self.is_valid_pod(pod_name):  # pod exists in a valid state
-            if not self.is_stale_update_time(updated_ts):
-                return False  # pod exists and key is updated recently
-
-            # pod exists but key is stale
-            self.logger.warning('Key `%s` in queue `%s` was last updated at '
-                                '`%s` (%s seconds ago) and pod `%s` is still '
-                                'alive with status %s but is_stale turned off.',
-                                key, self.cleaning_queue, updated_ts,
-                                updated_seconds, pod_name,
-                                self.pods[pod_name].status.phase)
-            # self.kill_pod(pod_name, self.namespace)
+            # if not self.is_stale_update_time(updated_ts):
+            #     return False  # pod exists and key is updated recently
+            #
+            # # pod exists but key is stale
+            # self.logger.warning('Key `%s` in queue `%s` was last updated at '
+            #                     '`%s` (%s seconds ago) and pod `%s` is still '
+            #                     'alive with status %s but is_stale turned off.',
+            #                     key, self.cleaning_queue, updated_ts,
+            #                     updated_seconds, pod_name,
+            #                     self.pods[pod_name].status.phase)
+            # # self.kill_pod(pod_name, self.namespace)
             return False
 
         # pod is not valid

--- a/redis_janitor/redis.py
+++ b/redis_janitor/redis.py
@@ -171,6 +171,7 @@ class RedisClient(object):
 
         def wrapper(*args, **kwargs):
             values = list(args) + list(kwargs.values())
+            values = [str(v) for v in values]
             while True:
                 try:
                     return redis_function(*args, **kwargs)

--- a/redis_janitor/redis.py
+++ b/redis_janitor/redis.py
@@ -154,7 +154,8 @@ class RedisClient(object):
             self.logger.warning('Encountered Error: %s. Using sentinel as '
                                 'primary redis client.', err)
 
-    def _get_redis_client(self, host, port):  # pylint: disable=R0201
+    @classmethod
+    def _get_redis_client(cls, host, port):
         return redis.StrictRedis(host=host, port=port,
                                  decode_responses=True,
                                  charset='utf-8')

--- a/redis_janitor/redis.py
+++ b/redis_janitor/redis.py
@@ -182,6 +182,17 @@ class RedisClient(object):
                                         str(name).upper(),
                                         ' '.join(values), self.backoff)
                     time.sleep(self.backoff)
+                except redis.exceptions.ResponseError as err:
+                    # check if redis just needs a backoff
+                    if 'BUSY' in str(err) and 'SCRIPT KILL' in str(err):
+                        self.logger.warning('Encountered %s: %s when calling '
+                                            '`%s %s`. Retrying in %s seconds.',
+                                            type(err).__name__, err,
+                                            str(name).upper(),
+                                            ' '.join(values), self.backoff)
+                        time.sleep(self.backoff)
+                    else:
+                        raise err
                 except Exception as err:
                     self.logger.error('Unexpected %s: %s when calling `%s %s`.',
                                       type(err).__name__, err,

--- a/redis_janitor/redis.py
+++ b/redis_janitor/redis.py
@@ -23,15 +23,103 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Fault tolerant RedisClient wrapper class"""
+"""Fault tolerant Redis client wrapper class"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import time
 import logging
+import time
+import random
 
 import redis
+
+
+REDIS_READONLY_COMMANDS = {
+    'publish',
+    'sunion',
+    'readonly',
+    'exists',
+    'hstrlen',
+    'lindex',
+    'scan',
+    'ping',
+    'ttl',
+    'wait',
+    'zscore',
+    'zrevrangebylex',
+    'sscan',
+    'geohash',
+    'getbit',
+    'hkeys',
+    'zrange',
+    'llen',
+    'auth',
+    'zcard',
+    'dbsize',
+    'subscribe',
+    'zrangebylex',
+    'zlexcount',
+    'mget',
+    'getrange',
+    'bitpos',
+    'lrange',
+    'discard',
+    'asking',
+    'client',
+    'pfselftest',
+    'unsubscribe',
+    'zrank',
+    'readwrite',
+    'hget',
+    'bitcount',
+    'randomkey',
+    'time',
+    'zrevrank',
+    'sinter',
+    'dump',
+    'strlen',
+    'unwatch',
+    'smembers',
+    'georadius',
+    'lastsave',
+    'slowlog',
+    'sismember',
+    'hexists',
+    'multi',
+    'sdiff',
+    'geopos',
+    'hscan',
+    'script',
+    'keys',
+    'hvals',
+    'pfcount',
+    'zscan',
+    'echo',
+    'command',
+    'select',
+    'zcount',
+    'substr',
+    'pttl',
+    'hlen',
+    'info',
+    'scard',
+    'geodist',
+    'srandmember',
+    'hgetall',
+    'pubsub',
+    'psubscribe',
+    'zrevrange',
+    'hmget',
+    'object',
+    'watch',
+    'zrangebyscore',
+    'get',
+    'type',
+    'zrevrangebyscore',
+    'punsubscribe',
+    'georadiusbymember',
+}
 
 
 class RedisClient(object):
@@ -39,23 +127,54 @@ class RedisClient(object):
     def __init__(self, host, port, backoff=1):
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.backoff = backoff
-        self._redis = self._get_redis_client(host=host, port=port)
+        self._sentinel = self._get_redis_client(host=host, port=port)
+        self._redis_master = self._sentinel
+        self._redis_slaves = [self._sentinel]
+        self._update_masters_and_slaves()
+
+    def _update_masters_and_slaves(self):
+        try:
+            self._sentinel.sentinel_masters()
+
+            sentinel_masters = self._sentinel.sentinel_masters()
+
+            for master_set in sentinel_masters:
+                master = sentinel_masters[master_set]
+
+                redis_master = self._get_redis_client(
+                    master['ip'], master['port'])
+
+                redis_slaves = []
+                for slave in self._sentinel.sentinel_slaves(master_set):
+                    redis_slave = self._get_redis_client(
+                        slave['ip'], slave['port'])
+                    redis_slaves.append(redis_slave)
+
+                self._redis_slaves = redis_slaves
+                self._redis_master = redis_master
+        except redis.exceptions.ResponseError as err:
+            self.logger.warning('Encountered Error: %s. Using sentinel as '
+                                'primary redis client.', err)
 
     def _get_redis_client(self, host, port):  # pylint: disable=R0201
-        return redis.StrictRedis(
-            host=host, port=port,
-            decode_responses=True,
-            charset='utf-8')
+        return redis.StrictRedis(host=host, port=port,
+                                 decode_responses=True,
+                                 charset='utf-8')
 
     def __getattr__(self, name):
-        redis_function = getattr(self._redis, name)
+        if name in REDIS_READONLY_COMMANDS:
+            redis_client = random.choice(self._redis_slaves)
+        else:
+            redis_client = self._redis_master
+
+        redis_function = getattr(redis_client, name)
 
         def wrapper(*args, **kwargs):
+            values = list(args) + list(kwargs.values())
             while True:
                 try:
                     return redis_function(*args, **kwargs)
                 except redis.exceptions.ConnectionError as err:
-                    values = list(args) + list(kwargs.values())
                     self.logger.warning('Encountered %s: %s when calling '
                                         '`%s %s`. Retrying in %s seconds.',
                                         type(err).__name__, err,
@@ -63,9 +182,9 @@ class RedisClient(object):
                                         ' '.join(values), self.backoff)
                     time.sleep(self.backoff)
                 except Exception as err:
-                    self.logger.error('Unexpected %s: %s when calling %s.',
+                    self.logger.error('Unexpected %s: %s when calling `%s %s`.',
                                       type(err).__name__, err,
-                                      str(name).upper())
+                                      str(name).upper(), ' '.join(values))
                     raise err
 
         return wrapper

--- a/redis_janitor/redis.py
+++ b/redis_janitor/redis.py
@@ -134,8 +134,6 @@ class RedisClient(object):
 
     def _update_masters_and_slaves(self):
         try:
-            self._sentinel.sentinel_masters()
-
             sentinel_masters = self._sentinel.sentinel_masters()
 
             for master_set in sentinel_masters:
@@ -162,20 +160,20 @@ class RedisClient(object):
                                  charset='utf-8')
 
     def __getattr__(self, name):
-        if name in REDIS_READONLY_COMMANDS:
-            redis_client = random.choice(self._redis_slaves)
-        else:
-            redis_client = self._redis_master
-
-        redis_function = getattr(redis_client, name)
 
         def wrapper(*args, **kwargs):
             values = list(args) + list(kwargs.values())
             values = [str(v) for v in values]
             while True:
                 try:
+                    if name in REDIS_READONLY_COMMANDS:
+                        redis_client = random.choice(self._redis_slaves)
+                    else:
+                        redis_client = self._redis_master
+                    redis_function = getattr(redis_client, name)
                     return redis_function(*args, **kwargs)
                 except redis.exceptions.ConnectionError as err:
+                    self._update_masters_and_slaves()
                     self.logger.warning('Encountered %s: %s when calling '
                                         '`%s %s`. Retrying in %s seconds.',
                                         type(err).__name__, err,

--- a/redis_janitor/redis_test.py
+++ b/redis_janitor/redis_test.py
@@ -37,17 +37,20 @@ import redis_janitor
 
 
 class DummyRedis(object):
-    def __init__(self, fail_tolerance=0, hard_fail=False):
+    def __init__(self, fail_tolerance=0, hard_fail=False, err=None):
         self.fail_count = 0
         self.fail_tolerance = fail_tolerance
         self.hard_fail = hard_fail
+        if err is None:
+            err = redis.exceptions.ConnectionError('thrown on purpose')
+        self.err = err
 
     def get_fail_count(self):
         if self.hard_fail:
             raise AssertionError('thrown on purpose')
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
-            raise redis.exceptions.ConnectionError('thrown on purpose')
+            raise self.err
         return self.fail_count
 
     def sentinel_masters(self):
@@ -62,7 +65,7 @@ class TestRedis(object):
 
     def test_redis_client(self):  # pylint: disable=R0201
         fails = random.randint(1, 3)
-        RedisClient = redis_consumer.redis.RedisClient
+        RedisClient = redis_janitor.redis.RedisClient
 
         # monkey patch _get_redis_client function to use DummyRedis client
         def _get_redis_client(*args, **kwargs):  # pylint: disable=W0613
@@ -75,6 +78,27 @@ class TestRedis(object):
 
         with pytest.raises(AttributeError):
             client.unknown_function()
+
+        # test ResponseError BUSY - should retry
+        def _get_redis_client_retry(*args, **kwargs):  # pylint: disable=W0613
+            err = redis.exceptions.ResponseError('BUSY SCRIPT KILL')
+            return DummyRedis(fail_tolerance=fails, err=err)
+
+        RedisClient._get_redis_client = _get_redis_client_retry
+
+        client = RedisClient(host='host', port='port', backoff=0)
+        assert client.get_fail_count() == fails
+
+        # test ResponseError other - should fail
+        def _get_redis_client_err(*args, **kwargs):  # pylint: disable=W0613
+            err = redis.exceptions.ResponseError('OTHER ERROR')
+            return DummyRedis(fail_tolerance=fails, err=err)
+
+        RedisClient._get_redis_client = _get_redis_client_err
+        client = RedisClient(host='host', port='port', backoff=0)
+
+        with pytest.raises(redis.exceptions.ResponseError):
+            client.get_fail_count()
 
         # test that other exceptions will raise.
         def _get_redis_client_bad(*args, **kwargs):  # pylint: disable=W0613

--- a/redis_janitor/redis_test.py
+++ b/redis_janitor/redis_test.py
@@ -50,12 +50,19 @@ class DummyRedis(object):
             raise redis.exceptions.ConnectionError('thrown on purpose')
         return self.fail_count
 
+    def sentinel_masters(self):
+        return {'mymaster': {'ip': 'master', 'port': 6379}}
+
+    def sentinel_slaves(self, _):
+        n = random.randint(1, 4)
+        return [{'ip': 'slave', 'port': 6379} for i in range(n)]
+
 
 class TestRedis(object):
 
     def test_redis_client(self):  # pylint: disable=R0201
         fails = random.randint(1, 3)
-        RedisClient = redis_janitor.redis.RedisClient
+        RedisClient = redis_consumer.redis.RedisClient
 
         # monkey patch _get_redis_client function to use DummyRedis client
         def _get_redis_client(*args, **kwargs):  # pylint: disable=W0613

--- a/redis_janitor/redis_test.py
+++ b/redis_janitor/redis_test.py
@@ -36,9 +36,11 @@ import pytest
 import redis_janitor
 
 
+FAIL_COUNT = 0
+
+
 class DummyRedis(object):
     def __init__(self, fail_tolerance=0, hard_fail=False, err=None):
-        self.fail_count = 0
         self.fail_tolerance = fail_tolerance
         self.hard_fail = hard_fail
         if err is None:
@@ -46,12 +48,13 @@ class DummyRedis(object):
         self.err = err
 
     def get_fail_count(self):
+        global FAIL_COUNT
         if self.hard_fail:
             raise AssertionError('thrown on purpose')
-        if self.fail_count < self.fail_tolerance:
-            self.fail_count += 1
+        if FAIL_COUNT < self.fail_tolerance:
+            FAIL_COUNT += 1
             raise self.err
-        return self.fail_count
+        return FAIL_COUNT
 
     def sentinel_masters(self):
         return {'mymaster': {'ip': 'master', 'port': 6379}}
@@ -64,6 +67,8 @@ class DummyRedis(object):
 class TestRedis(object):
 
     def test_redis_client(self):  # pylint: disable=R0201
+        global FAIL_COUNT
+
         fails = random.randint(1, 3)
         RedisClient = redis_janitor.redis.RedisClient
 
@@ -75,6 +80,7 @@ class TestRedis(object):
 
         client = RedisClient(host='host', port='port', backoff=0)
         assert client.get_fail_count() == fails
+        FAIL_COUNT = 0  # reset for the next test
 
         with pytest.raises(AttributeError):
             client.unknown_function()
@@ -88,6 +94,7 @@ class TestRedis(object):
 
         client = RedisClient(host='host', port='port', backoff=0)
         assert client.get_fail_count() == fails
+        FAIL_COUNT = 0  # reset for the next test
 
         # test ResponseError other - should fail
         def _get_redis_client_err(*args, **kwargs):  # pylint: disable=W0613


### PR DESCRIPTION
The Redis client now uses Sentinel to route READONLY requests to the slave nodes and WRITE request to the master node.