### PR TITLE
Janitor supports cleaning multiple base queues

### DIFF
--- a/clean-redis.py
+++ b/clean-redis.py
@@ -78,7 +78,10 @@ if __name__ == '__main__':
         decouple.config('REDIS_HOST', default='redis-master'),
         decouple.config('REDIS_PORT', default=6379, cast=int))
 
-    all_janitors = {}
+    janitor = redis_janitor.RedisJanitor(
+        redis_client=REDIS,
+        queue=QUEUE,
+        stale_time=STALE_TIME)
 
     queues = ' and '.join('`%s:*`' % q for q in janitor.processing_queues)
     _logger.info('Janitor initialized. Cleaning queues `%s` and %s every %ss.',

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -84,9 +84,10 @@ if __name__ == '__main__':
         queue_delimiter=QUEUE_DELIMITER,
         stale_time=STALE_TIME)
 
+    base_queues = ' and '.join(q for q in janitor.queues)
     queues = ' and '.join('`%s:*`' % q for q in janitor.processing_queues)
     _logger.info('Janitor initialized. Cleaning queues `%s` and %s every %ss.',
-                 janitor.queue, queues, INTERVAL)
+                 base_queues, queues, INTERVAL)
 
     while True:
         try:

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -84,9 +84,9 @@ if __name__ == '__main__':
         queue_delimiter=QUEUE_DELIMITER,
         stale_time=STALE_TIME)
 
-    base_queues = ' and '.join(q for q in janitor.queues)
+    base_queues = ' and '.join('`%s`' % q for q in janitor.queues)
     queues = ' and '.join('`%s:*`' % q for q in janitor.processing_queues)
-    _logger.info('Janitor initialized. Cleaning queues `%s` and %s every %ss.',
+    _logger.info('Janitor initialized. Cleaning queues %s and %s every %ss.',
                  base_queues, queues, INTERVAL)
 
     while True:

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -81,28 +81,16 @@ if __name__ == '__main__':
     janitor = redis_janitor.RedisJanitor(
         redis_client=REDIS,
         queue=QUEUE,
+        queue_delimiter=QUEUE_DELIMITER,
         stale_time=STALE_TIME)
 
     queues = ' and '.join('`%s:*`' % q for q in janitor.processing_queues)
     _logger.info('Janitor initialized. Cleaning queues `%s` and %s every %ss.',
                  janitor.queue, queues, INTERVAL)
 
-    for queue in set(QUEUE.split(QUEUE_DELIMITER)):
-        janitor = redis_janitor.RedisJanitor(
-            redis_client=REDIS,
-            queue=queue,
-            stale_time=STALE_TIME)
-
-        all_janitors[queue] = janitor
-
-        _logger.info('Janitors initialized. '
-                     'Cleaning queues `%s` and `%s:*` every `%s` seconds.',
-                     janitor.queue, janitor.processing_queue, INTERVAL)
-
     while True:
         try:
-            for q, j in all_janitors.items():
-                j.clean()
+            janitor.clean()
             time.sleep(INTERVAL)
         except Exception as err:  # pylint: disable=broad-except
             _logger.critical('Fatal Error: %s: %s', type(err).__name__, err)

--- a/clean-redis.py
+++ b/clean-redis.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
     for queue in set(QUEUE.split(QUEUE_DELIMITER)):
         janitor = redis_janitor.RedisJanitor(
             redis_client=REDIS,
-            queue=QUEUE,
+            queue=queue,
             stale_time=STALE_TIME)
 
         all_janitors[queue] = janitor

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -43,6 +43,7 @@ class RedisJanitor(object):
     def __init__(self,
                  redis_client,
                  queue,
+                 queue_delimiter=',',
                  namespace='default',
                  backoff=3,
                  stale_time=600,  # 10 minutes
@@ -51,7 +52,7 @@ class RedisJanitor(object):
         self.redis_client = redis_client
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.backoff = backoff
-        self.queues = str(queue).lower().split(',')
+        self.queues = str(queue).lower().split(queue_delimiter)
         self.namespace = namespace
         self.stale_time = int(stale_time)
         self.failure_stale_seconds = failure_stale_seconds

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -51,7 +51,7 @@ class RedisJanitor(object):
         self.redis_client = redis_client
         self.logger = logging.getLogger(str(self.__class__.__name__))
         self.backoff = backoff
-        self.queue = str(queue).lower()
+        self.queues = str(queue).lower().split(',')
         self.namespace = namespace
         self.stale_time = int(stale_time)
         self.failure_stale_seconds = failure_stale_seconds
@@ -70,10 +70,12 @@ class RedisJanitor(object):
         }
 
         self.total_repairs = 0
-        self.processing_queues = [
-            'processing-{}'.format(self.queue),
-            'processing-{}-zip'.format(self.queue)
-        ]
+        self.processing_queues = []
+        for q in self.queues:
+            self.processing_queues.extend([
+                'processing-{}'.format(q),
+                'processing-{}-zip'.format(q)
+            ])
         self.cleaning_queue = ''  # update this in clean()
 
     def get_core_v1_client(self):

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -351,17 +351,21 @@ class TestJanitor(object):
         assert janitor.clean_key('stalekey:inprogress') is True
 
     def test_clean(self):
-        queue = 'q'
-        janitor = self.get_client(queue=queue)
+        queues = 'q1,q2'
+        q1, q2 = queues.split(',')
+        janitor = self.get_client(queue=queues)
         whitelisted = janitor.whitelisted_pods[0]
         janitor.redis_client.keys = [
-            'processing-{q}:pod'.format(q=queue),
-            'processing-{q}:{pod}'.format(q=queue, pod=whitelisted),
-            'processing-{q}:pod'.format(q=queue),
+            'processing-{q}:pod'.format(q=q1),
+            'processing-{q}:{pod}'.format(q=q1, pod=whitelisted),
+            'processing-{q}:pod'.format(q=q1),
+            'processing-{q}:pod'.format(q=q2),
+            'processing-{q}:{pod}'.format(q=q2, pod=whitelisted),
+            'processing-{q}:pod'.format(q=q2),
             'other key',
         ]
         janitor.clean_key = lambda *x: True
         janitor.is_whitelisted = lambda x: int(x) % 2 == 0
         janitor.lrange = []
         janitor.clean()
-        assert janitor.total_repairs == 3 ** 2  # valid keys ** 2
+        assert janitor.total_repairs == 6 ** 2  # valid keys ** 2


### PR DESCRIPTION
The Janitor tries to split the `QUEUE` with a `QUEUE_DELIMITER` (default to ","), and will clean each base queue and its processing queues as before.

Fixes #19 