### PR TITLE
Memory management improvements

### DIFF
--- a/clean-redis.py
+++ b/clean-redis.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import gc
 import logging
 import logging.handlers
 import sys
@@ -94,6 +95,7 @@ if __name__ == '__main__':
     while True:
         try:
             janitor.clean()
+            gc.collect()
             time.sleep(INTERVAL)
         except Exception as err:  # pylint: disable=broad-except
             _logger.critical('Fatal Error: %s: %s', type(err).__name__, err)

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -169,7 +169,8 @@ class RedisJanitor(object):
     def _update_pods(self):
         """Refresh pod data and update timestamp"""
         namespaced_pods = self.list_pod_for_all_namespaces()
-        self.pods = {pod.metadata.name: pod for pod in namespaced_pods}
+        self.pods = {pod.metadata.name: pod.status.phase
+                     for pod in namespaced_pods}
         self.pods_updated_at = datetime.datetime.now(pytz.UTC)
 
     def update_pods(self):
@@ -189,7 +190,7 @@ class RedisJanitor(object):
         self.update_pods()  # only updates if stale
         is_valid = False
         if pod_name in self.pods:
-            pod_phase = self.pods[pod_name].status.phase
+            pod_phase = self.pods[pod_name]
             if pod_phase in self.valid_pod_phases:
                 is_valid = True
         return is_valid
@@ -234,7 +235,7 @@ class RedisJanitor(object):
             #                     'alive with status %s but is_stale turned off.',
             #                     key, self.cleaning_queue, updated_ts,
             #                     updated_seconds, pod_name,
-            #                     self.pods[pod_name].status.phase)
+            #                     self.pods[pod_name])
             # # self.kill_pod(pod_name, self.namespace)
             return False
 
@@ -248,7 +249,7 @@ class RedisJanitor(object):
             self.logger.info('Key `%s` in queue `%s` was last updated by '
                              'pod `%s` %s seconds ago, but that pod has status'
                              ' %s.', key, self.cleaning_queue, pod_name,
-                             updated_seconds, self.pods[pod_name].status.phase)
+                             updated_seconds, self.pods[pod_name])
         return True
 
     def clean_key(self, key):

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -271,7 +271,7 @@ class RedisJanitor(object):
     def clean(self):
         cleaned = 0
 
-        for q in self.get_processing_keys(count=1000):
+        for q in self.get_processing_keys(count=100):
             self.cleaning_queue = q
             for i, key in enumerate(self.redis_client.lrange(q, 0, -1)):
                 if i >= 1:

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -271,7 +271,7 @@ class RedisJanitor(object):
     def clean(self):
         cleaned = 0
 
-        for q in self.get_processing_keys(count=100):
+        for q in self.get_processing_keys(count=1000):
             self.cleaning_queue = q
             for i, key in enumerate(self.redis_client.lrange(q, 0, -1)):
                 if i >= 1:

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -186,11 +186,7 @@ class RedisJanitor(object):
 
     def is_valid_pod(self, pod_name):
         self.update_pods()  # only updates if stale
-        is_valid = False
-        if pod_name in self.pods:
-            pod_phase = self.pods[pod_name]
-            if pod_phase in self.valid_pod_phases:
-                is_valid = True
+        is_valid = self.pods.get(pod_name) in self.valid_pod_phases
         return is_valid
 
     def _timestamp_to_age(self, ts):

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -287,3 +287,8 @@ class RedisJanitor(object):
             self.total_repairs += cleaned
             self.logger.info('Repaired %s key%s (%s total).', cleaned,
                              's' if cleaned else '', self.total_repairs)
+
+        # reset state to like new
+        self.cleaning_queue = ''
+        self.pods = {}
+        self.pods_updated_at = None

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -168,7 +168,7 @@ class RedisJanitor(object):
 
     def _update_pods(self):
         """Refresh pod data and update timestamp"""
-        namespaced_pods = self.list_namespaced_pod()
+        namespaced_pods = self.list_pod_for_all_namespaces()
         self.pods = {pod.metadata.name: pod.status.phase
                      for pod in namespaced_pods}
         self.pods_updated_at = datetime.datetime.now(pytz.UTC)

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -47,7 +47,6 @@ class RedisJanitor(object):
                  namespace='default',
                  backoff=3,
                  stale_time=600,  # 10 minutes
-                 failure_stale_seconds=60,
                  pod_refresh_interval=5,):
         self.redis_client = redis_client
         self.logger = logging.getLogger(str(self.__class__.__name__))
@@ -55,7 +54,6 @@ class RedisJanitor(object):
         self.queues = str(queue).lower().split(queue_delimiter)
         self.namespace = namespace
         self.stale_time = int(stale_time)
-        self.failure_stale_seconds = failure_stale_seconds
         self.pod_refresh_interval = int(pod_refresh_interval)
 
         # empty initializers, update them with _update_pods

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -211,7 +211,7 @@ class RedisJanitor(object):
         stale_time = stale_time if stale_time else self.stale_time
         if not updated_time:
             return False
-        if not stale_time > 0:
+        if stale_time <= 0:
             return False
         last_updated = self._timestamp_to_age(updated_time)
         return last_updated >= stale_time
@@ -259,7 +259,7 @@ class RedisJanitor(object):
             'updated_by',
         ]
         res = self.redis_client.hmget(key, *required_keys)
-        hvals = {k: v for k, v in zip(required_keys, res)}
+        hvals = dict(zip(required_keys, res))
 
         should_clean = self.should_clean_key(key, hvals.get('updated_at'))
 

--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -168,7 +168,7 @@ class RedisJanitor(object):
 
     def _update_pods(self):
         """Refresh pod data and update timestamp"""
-        namespaced_pods = self.list_pod_for_all_namespaces()
+        namespaced_pods = self.list_namespaced_pod()
         self.pods = {pod.metadata.name: pod.status.phase
                      for pod in namespaced_pods}
         self.pods_updated_at = datetime.datetime.now(pytz.UTC)

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -221,7 +221,24 @@ class TestJanitor(object):
         assert int(janitor.remove_key_from_queue(valid_key)) == 1
         assert int(janitor.remove_key_from_queue(invalid_key)) == 0
 
-    def test__udpate_pods(self):
+    def test_repair_redis_key(self):
+        janitor = self.get_client()
+
+        def remove_key(_):
+            return True
+
+        # Remove key and put it back in the work queue
+        janitor.remove_key_from_queue = remove_key
+        janitor.repair_redis_key('testkey')
+
+        def fail_to_remove(_):
+            return False
+
+        # Could not remove key, should log it.
+        janitor.remove_key_from_queue = fail_to_remove
+        janitor.repair_redis_key('testkey')
+
+    def test__update_pods(self):
         janitor = self.get_client()
         janitor._update_pods()
         # pylint: disable=E1101

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -230,10 +230,8 @@ class TestJanitor(object):
         assert isinstance(janitor.pods_updated_at, datetime.datetime)
         assert len(janitor.pods) == len(expected)
         for e in expected:
-            name = e.metadata.name
-            assert name in janitor.pods
-            assert janitor.pods[name].metadata.name == name
-            assert janitor.pods[name].status.phase == e.status.phase
+            assert e.metadata.name in janitor.pods
+            assert janitor.pods[e.metadata.name] == e.status.phase
 
     def test_udpate_pods(self):
         janitor = self.get_client(pod_refresh_interval=10000)
@@ -244,10 +242,8 @@ class TestJanitor(object):
         assert isinstance(janitor.pods_updated_at, datetime.datetime)
         assert len(janitor.pods) == len(expected)
         for e in expected:
-            name = e.metadata.name
-            assert name in janitor.pods
-            assert janitor.pods[name].metadata.name == name
-            assert janitor.pods[name].status.phase == e.status.phase
+            assert e.metadata.name in janitor.pods
+            assert janitor.pods[e.metadata.name] == e.status.phase
 
         # now that we've called it once, lets make sure it doesnt happen again
         janitor.pods = {}  # resetting this for test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 redis==3.4.1
-kubernetes==9.0.0
+kubernetes==10.0.0
 pytz==2019.1
 python-dateutil==2.8.0
 python-decouple==3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-redis==3.2.1
+redis==3.4.1
 kubernetes==9.0.0
 pytz==2019.1
 python-dateutil==2.8.0


### PR DESCRIPTION
* Update redis client to 3.4.1
* Update kubernetes client for kube 1.14.X
* Call `gc.collect` after every `janitor.clean()`
* Only save pod name and pod status in `janitor.pods`
* Code style improvements
* `test_repair_redis_key` to maintain coverage