### PR TITLE
Remove empty keys from the processing queue.

### DIFF
--- a/redis_janitor/janitors.py
+++ b/redis_janitor/janitors.py
@@ -214,8 +214,9 @@ class RedisJanitor(object):
         """Return a boolean if the key should be cleaned"""
         pod_name = self.cleaning_queue.split(':')[-1]
 
+        updated_seconds = self._timestamp_to_age(updated_ts)
+
         if updated_seconds <= self.pod_refresh_interval * 3:
-            self.logger.debug('%s is "fresh" updated seconds', updated_seconds)
             return False  # this is too fresh for our pod data
 
         if self.is_valid_pod(pod_name):  # pod exists in a valid state
@@ -230,7 +231,6 @@ class RedisJanitor(object):
             #                     updated_seconds, pod_name,
             #                     self.pods[pod_name])
             # # self.kill_pod(pod_name, self.namespace)
-            self.logger.debug('%s is a valid pod name', pod_name)
             return False
 
         # pod is not valid

--- a/redis_janitor/janitors_test.py
+++ b/redis_janitor/janitors_test.py
@@ -363,6 +363,11 @@ class TestJanitor(object):
         janitor.cleaning_queue = 'processing-q:bad'
         assert janitor.clean_key('stalekey:inprogress') is True
 
+        # test invalid key is removed
+        janitor.cleaning_queue = 'processing-q:bad'
+        janitor.redis_client.hmget = lambda x, *y: [None] * len(y)
+        assert janitor.clean_key('stalekey:inprogress') is True
+
     def test_clean(self):
         queues = 'q1,q2'
         num_queues = len(queues.split(','))


### PR DESCRIPTION
If a key is empty (has no values), then the call to `HGET updated_at` will return `None`. Originally, `None` values were considered to mean that they key has not yet been updated. However, if a key is expired, the value will also be `None`. To resolve expired keys getting stuck in a "valid" loop, the janitor will check if every value of the `HMGET` call is `None`. If so, the janitor will determine that the key is invalid, and remove it from the processing queue.