### PR TITLE
Update dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -106,3 +106,4 @@ venv.bak/
 # OS Files
 .DS_Store
 .vscode
+.github/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-redis==3.4.1
-kubernetes==10.0.0
+kubernetes==11.0.0
 pytz==2019.1
 python-dateutil==2.8.0
 python-decouple==3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
+redis>=3.4.1<4
 kubernetes==11.0.0
 pytz==2019.1
-python-dateutil==2.8.0
-python-decouple==3.1
+python-dateutil>=2.8.0
+python-decouple>=3.1,<4


### PR DESCRIPTION
* Add `.github` folder to `.dockerignore`
* Update `kubernetes` client to `11.0.0` for compatibility with kube versions 1.14, 1.15, 1.16.
* Loosen version restrictions on `redis`, `python-dateutil` and `python-decouple` to install future minor version updates.